### PR TITLE
Strict mode: enforce handling of command failures (--strict)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .runic,
-    .version = "0.4.0",
+    .version = "0.5.0",
     .fingerprint = 0x3b1c123a318e6cf2, // Changing this has security and trust implications.
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/cmd/runic/main-utils.zig
+++ b/cmd/runic/main-utils.zig
@@ -18,6 +18,8 @@ pub const CliConfig = struct {
     debug_ir: bool = false,
     dry_run: bool = false,
     verbose: bool = false,
+    /// Strict mode: also require handling of command failures (`ExecutableError`).
+    strict: bool = false,
 
     pub const ScriptInvocation = struct {
         path: []const u8,
@@ -639,6 +641,7 @@ pub fn parseCommandLine(allocator: Allocator, args: std.process.Args) !ParseResu
     var debug_ir = false;
     var dry_run = false;
     var verbose = false;
+    var strict = false;
     var parsing_options = true;
     var idx: usize = 1;
 
@@ -694,6 +697,10 @@ pub fn parseCommandLine(allocator: Allocator, args: std.process.Args) !ParseResu
             }
             if (argEqual(arg, "--verbose")) {
                 verbose = true;
+                continue;
+            }
+            if (argEqual(arg, "--strict") or argEqual(arg, "-e")) {
+                strict = true;
                 continue;
             }
             if (std.mem.startsWith(u8, arg, trace_prefix)) {
@@ -778,6 +785,7 @@ pub fn parseCommandLine(allocator: Allocator, args: std.process.Args) !ParseResu
             .debug_ir = debug_ir,
             .dry_run = dry_run,
             .verbose = verbose,
+            .strict = strict,
         },
     };
 
@@ -799,6 +807,7 @@ pub fn printUsage(writer: *std.Io.Writer) !void {
         \\  --print-ast          Parse the script and emit its AST instead of executing.
         \\  --print-tokens       Dump the raw lexer tokens for the provided script path.
         \\  --type-check-only    Dry run with only type checking.
+        \\  --strict, -e         Also require handling of command failures (ExecutableError).
         \\  --debug-ir           Enable IR debug mode.
         \\  --eval, -c SOURCE    Execute Runic source passed directly on the command line.
         \\

--- a/cmd/runic/run_script.zig
+++ b/cmd/runic/run_script.zig
@@ -93,7 +93,7 @@ pub fn runScript(
     }
 
     if (!config.skip_type_check) {
-        var type_checker = TypeChecker.init(io, allocator, &document_store.document_store, env_map);
+        var type_checker = TypeChecker.init(io, allocator, &document_store.document_store, env_map, config.strict);
         defer type_checker.deinit();
 
         const type_checker_result = type_checker.typeCheck(resolvedPath) catch |err| {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,12 @@ Version numbers follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **Strict mode (`--strict` / `-e`).** A `set -e`-style opt-in that also requires
+  handling of command failures (`ExecutableError`), which are exempt by default.
+  Off by default, so existing scripts are unaffected; when on, a bare command
+  whose failure isn't `catch`/`||`'d is a compile error.
 
 ## [0.4.0] — 2026-06-30
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ Version numbers follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [0.5.0] — 2026-07-01
+
 ### Added
 
 - **Strict mode (`--strict` / `-e`).** A `set -e`-style opt-in that also requires

--- a/docs/features.md
+++ b/docs/features.md
@@ -150,6 +150,18 @@ E.Bad           // error: error is not handled; use catch (or || to discard) or 
 E.Bad catch 0   // ok
 ```
 
+**Strict mode (`--strict`, or `-e`).** By default a command's `ExecutableError`
+is exempt (bash-like: a bare `ls` runs and its failure is ignored). Passing
+`--strict` removes that exemption — a command failure must be handled too, just
+like a user error. It's a `set -e`-style opt-in, off by default, so existing
+scripts are unaffected.
+
+```rn
+ls "/missing"                     // default: runs, failure ignored
+                                  // --strict: error — must handle it
+const out = ls "/missing" catch "" // ok under --strict
+```
+
 #### Inspecting variants with `match`
 
 `match` dispatches on an error's variant and can capture the payload:

--- a/src/lsp/workspace.zig
+++ b/src/lsp/workspace.zig
@@ -73,6 +73,7 @@ pub const Workspace = struct {
                 allocator,
                 &documentStore.document_store,
                 env_map,
+                false, // strict mode is a CLI opt-in, not applied to LSP analysis
             ),
         };
 

--- a/src/semantic/type-checker.zig
+++ b/src/semantic/type-checker.zig
@@ -19,6 +19,10 @@ pub const TypeChecker = struct {
     document_store: *DocumentStore,
     modules: std.StringArrayHashMapUnmanaged(*Scope),
     env: ?*std.process.Environ.Map = null,
+    /// Strict mode (`--strict`): also require handling of command failures
+    /// (`ExecutableError`), which are otherwise exempt (bash-like exit-code
+    /// model). A `set -e`-style opt-in — off by default.
+    strict: bool = false,
     /// Stack of the enclosing functions' declared stdout types. Pushed when a
     /// function body is type-checked and consulted by `runYield` so that every
     /// `yield &1` is validated in the scope where it actually appears (e.g.
@@ -118,6 +122,7 @@ pub const TypeChecker = struct {
         allocator: std.mem.Allocator,
         document_store: *DocumentStore,
         env: *std.process.Environ.Map,
+        strict: bool,
     ) TypeChecker {
         const logging_enabled_s = env.get("RUNIC_LOG_" ++ logging_name) orelse "";
         const logging_enabled = std.mem.eql(u8, logging_enabled_s, "1");
@@ -129,6 +134,7 @@ pub const TypeChecker = struct {
             .document_store = document_store,
             .modules = .empty,
             .env = env,
+            .strict = strict,
         };
     }
 
@@ -1311,13 +1317,17 @@ pub const TypeChecker = struct {
     }
 
     /// True for an error union or error value whose set is not the builtin
-    /// `ExecutableError` (commands keep the implicit exit-code model).
+    /// `ExecutableError` (commands keep the implicit exit-code model). In strict
+    /// mode (`--strict`) command failures are *not* exempt: a bare command
+    /// (`.execution`) and an `ExecutableError` union/set also count as unhandled.
     fn isUnhandledErrorType(self: *TypeChecker, t: *const ast.TypeExpr) bool {
         const unaliased = self.unaliasType(t);
         return switch (unaliased.*) {
-            .error_union => |error_union| !self.isExecutableErrorSet(error_union.err_set),
-            .error_set => !self.isExecutableErrorSet(unaliased),
+            .error_union => |error_union| self.strict or !self.isExecutableErrorSet(error_union.err_set),
+            .error_set => self.strict or !self.isExecutableErrorSet(unaliased),
             .err => true,
+            // A bare command's result — exempt by default, enforced under strict.
+            .execution => self.strict,
             else => false,
         };
     }

--- a/tests/cli_strict.sh
+++ b/tests/cli_strict.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Verifies `--strict` mode: command failures (ExecutableError), which are exempt
+# by default, must be handled. Runs a couple of inline scripts through the built
+# binary with and without --strict.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="${RUNIC_REPO_ROOT:-$(cd "$script_dir/.." && pwd)}"
+repo_root="$(cd "$repo_root" && pwd)"
+
+if ! command -v zig >/dev/null 2>&1; then
+  echo "zig is required for CLI strict tests but was not found on PATH." >&2
+  exit 1
+fi
+
+(
+  cd "$repo_root"
+  zig build >/dev/null
+)
+
+runic_bin="$repo_root/zig-out/bin/runic"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# A bare command whose failure is ignored.
+bare="$tmp_dir/bare.rn"
+printf 'fn Void @() Void\nls "/nonexistent-xyz-strict"\n' > "$bare"
+
+# The same command, handled.
+handled="$tmp_dir/handled.rn"
+printf 'fn Void @() Void\nconst r = ls "/nonexistent-xyz-strict" catch "handled"\n' > "$handled"
+
+run_status() {
+  set +e
+  (cd "$repo_root" && "$runic_bin" "$@") >/dev/null 2>&1
+  local s=$?
+  set -e
+  echo "$s"
+}
+
+# Default mode: a bare command failure is exempt (runs, exit 0).
+echo "-- bare command, default mode (expect exit 0)"
+if [[ "$(run_status "$bare")" != "0" ]]; then
+  echo "FAIL: bare command should be exempt without --strict" >&2
+  exit 1
+fi
+
+# Strict mode: the same bare command is a compile error (exit 1).
+echo "-- bare command, --strict (expect exit 1)"
+if [[ "$(run_status --strict "$bare")" != "1" ]]; then
+  echo "FAIL: bare command should be a compile error under --strict" >&2
+  exit 1
+fi
+
+# Strict mode: handled command passes.
+echo "-- handled command, --strict (expect exit 0)"
+if [[ "$(run_status --strict "$handled")" != "0" ]]; then
+  echo "FAIL: handled command should pass under --strict" >&2
+  exit 1
+fi
+
+echo "CLI strict-mode tests passed (3 cases)."


### PR DESCRIPTION
By default a command's `ExecutableError` is exempt from mandatory error handling
  (bash-like: a bare `ls` runs and its failure is ignored). `--strict` (alias `-e`)
  removes that exemption — a command failure must be handled (`catch`/`||`/propagate)
  or it's a compile error.

      ls "/missing"                      # default: runs, failure ignored
                                         # --strict: error — must handle it
      const out = ls "/missing" catch "" # ok under --strict

  - Off by default, so existing scripts/examples/tests are unaffected.
  - A `set -e`-style opt-in, but stricter: explicit compile-time handling of every
    bare command (including `echo`), not a runtime abort.

  Implementation: `CliConfig.strict` (parsed from `--strict`/`-e`) threaded into
  `TypeChecker.init`; `isUnhandledErrorType` treats a bare command (`.execution`)
  and an `ExecutableError` union/set as unhandled when strict; LSP passes
  `strict = false`. Docs + CHANGELOG updated; `tests/cli_strict.sh` covers
  default-exempt / strict-error / strict-handled (run by CI). Default behavior
  unchanged — full CI green.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)