### PR TITLE
Fix function calls used as arithmetic operands (0.6.1)

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .runic,
-    .version = "0.6.0",
+    .version = "0.6.1",
     .fingerprint = 0x3b1c123a318e6cf2, // Changing this has security and trust implications.
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,17 @@ Version numbers follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.
 
 _Nothing yet._
 
+## [0.6.1] — 2026-08-20
+
+### Fixed
+
+- A function call (or UFCS method call) used directly as an **arithmetic
+  operand** — e.g. `${five - 1}` or `${p.magSq - q.magSq}` — no longer crashes
+  with "Could not dereference value of type thread". Such operands are now
+  captured so they yield their value instead of a fork/thread handle, and two
+  call operands in one expression are stabilized so they don't clobber each
+  other.
+
 ## [0.6.0] — 2026-08-19
 
 ### Added

--- a/src/ir/compiler.zig
+++ b/src/ir/compiler.zig
@@ -6134,6 +6134,23 @@ pub const IRCompiler = struct {
         };
     }
 
+    /// Compiles an operand of an arithmetic expression as a value. An operand
+    /// that produces output (a function call, UFCS method, pipeline, …) must be
+    /// *captured* so it yields its value rather than a fork/thread handle;
+    /// the captured value is stabilized into a fresh ref so a second capturing
+    /// operand can't clobber it (both would otherwise land in `%r`). A plain
+    /// binding/literal operand takes the cheap path.
+    fn compileArithmeticOperand(self: *IRCompiler, source: anytype, expr: *ast.Expression) Error!Result {
+        if (self.analyzeExpressionEffects(expr).needs_stdio_capture) {
+            const captured = try self.compileExpressionWithCapture(source, expr);
+            const type_expr = captured.typeExpr();
+            const ref = try self.newRef(source, "arith_operand");
+            try self.set(source, ref, stableResultSource(captured));
+            return .from(ref.dereference().typed(type_expr));
+        }
+        return (try self.compileExpression(expr)).dereference();
+    }
+
     fn compileBinary(
         self: *IRCompiler,
         source: anytype,
@@ -6143,8 +6160,8 @@ pub const IRCompiler = struct {
 
         switch (binary.op) {
             .add, .subtract, .multiply, .divide, .remainder => {
-                const left = (try self.compileExpression(binary.left)).dereference();
-                const right = (try self.compileExpression(binary.right)).dereference();
+                const left = try self.compileArithmeticOperand(source, binary.left);
+                const right = try self.compileArithmeticOperand(source, binary.right);
 
                 if (evaluateArithmetic(.from(binary.op), left.source, right.source)) |comptime_result| {
                     return .from(comptime_result);

--- a/tests/features/call_in_arithmetic_regression.rn
+++ b/tests/features/call_in_arithmetic_regression.rn
@@ -1,0 +1,29 @@
+# A function call (or UFCS method call) used directly as an arithmetic operand
+# must capture the function's yielded value, not leave a fork/thread handle.
+# Two such operands in one expression must each be stabilized so they don't
+# clobber a shared result register.
+fn Void @() Void
+
+fn Void five() Int { yield 5 }
+fn Void three() Int { yield 3 }
+
+# A single call as an operand.
+echo "five-1=${five - 1}"
+
+# Two calls in one expression.
+echo "five-three=${five - three}"
+echo "five*three=${five * three}"
+
+# UFCS method calls in arithmetic (receiver is a struct).
+const Point = struct { x: Int, y: Int }
+fn Void magSq(self: Point) Int { yield self.x * self.x + self.y * self.y }
+const p: Point = Point{ .x = 3, .y = 4 }
+const q: Point = Point{ .x = 1, .y = 2 }
+echo "p.magSq-q.magSq=${p.magSq - q.magSq}"
+
+# A UFCS call on a nested field receiver, twice in one expression (kept positive
+# — Int is unsigned, so the larger magnitude goes first).
+const Seg = struct { from: Point, to: Point }
+fn Void span(s: Seg) Int { yield s.from.magSq - s.to.magSq }
+const seg: Seg = Seg{ .from = p, .to = q }
+echo "span=${span seg}"

--- a/tests/features/call_in_arithmetic_regression.stdout
+++ b/tests/features/call_in_arithmetic_regression.stdout
@@ -1,0 +1,5 @@
+five-1=4
+five-three=2
+five*three=15
+p.magSq-q.magSq=20
+span=20


### PR DESCRIPTION
Patch release **0.6.1**. Fixes a pre-existing crash and bumps the version.

  ## The bug

  A function call — or a UFCS method call — used **directly as an arithmetic
  operand** crashed at runtime with *"Could not dereference value of type
  thread"*:

      fn Void five() Int { yield 5 }
      echo "${five - 1}"            # ✗ crashed

      const Point = struct { x: Int, y: Int }
      fn Void magSq(self: Point) Int { yield self.x * self.x + self.y * self.y }
      echo "${p.magSq - q.magSq}"    # ✗ crashed

  Arithmetic operands were compiled without stdio capture, so a call operand
  evaluated to the function's fork/thread handle instead of its yielded value —
  which the arithmetic op then failed to dereference. (Interpolating a call on its
  own, `${five}`, worked because that path captures.)

  ## The fix

  `compileArithmeticOperand` now captures an operand that produces output (a call,
  UFCS method, or pipeline) so it yields its value, and stabilizes the captured
  value into a fresh ref so two call operands in one expression don't clobber a
  shared result register. Plain binding/literal operands keep the cheap path
  unchanged.

      echo "${five - 1}"             # 4
      echo "${five - three}"         # 2
      echo "${p.magSq - q.magSq}"    # 20

  Surfaced while writing the structs release example (`seg.to.magSq -
  seg.from.magSq`).

  ## Testing

  New `tests/features/call_in_arithmetic_regression.rn` covers single/multiple
  plain calls and UFCS calls (including a nested-field receiver) in arithmetic.
  Full CI green: 13/13 unit, 42 diagnostics, 8 examples, 109 smoke, 3 strict.

  ## Changes

  - `fix(ir)`: capture a function-call operand in arithmetic
  - `release`: bump 0.6.0 → 0.6.1 + CHANGELOG entry