### PR TITLE
Release 0.8.1 — LSP protocol correctness & stabilization

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .runic,
-    .version = "0.8.0",
+    .version = "0.8.1",
     .fingerprint = 0x3b1c123a318e6cf2, // Changing this has security and trust implications.
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,52 @@ Version numbers follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-09-05
+
+Bug fixes and stabilization after the 0.8.0 language-server build-out. The
+focus is LSP protocol correctness and resilience.
+
+### Fixed
+
+- **Rename / code-action edits crashed clients** — a `WorkspaceEdit`'s
+  `documentChanges` entries were serialized as `{"textDocumentEdit": {…}}`
+  instead of the bare `TextDocumentEdit` the protocol requires, so applying a
+  rename or the "add type annotation" quick fix failed in editors (Neovim
+  reported `attempt to index local 'text_document' (a nil value)`).
+- **More LSP protocol encodings** — `InsertTextMode` and `CompletionItemTag`
+  now serialize as their numeric codes, and `ProgressToken` as a bare scalar,
+  completing the numeric-code pass started in 0.8.0. Responses are now emitted
+  in JSON-RPC result-XOR-error form (no stray `"error": null` beside a result),
+  and the server's debug log now matches the exact bytes sent on the wire.
+- **Crash on an out-of-bounds position** — a hover/definition/rename/… request
+  at a line past end-of-file, or a character past the end of a line, ran the
+  position scan off the end of the buffer and crashed the server. Such a
+  position now resolves to nothing and the request returns an empty result.
+- **A malformed request killed the session** — an unparseable request body
+  propagated an error out of the main loop and terminated the server, dropping
+  every request after it. A malformed message is now logged and dropped, and
+  the session continues.
+
+### Changed
+
+- **Workspace indexing is lazy** — the full `.rn` workspace scan now runs on the
+  first workspace-wide request (symbol search, references, rename, cross-file
+  definition) for a client-provided root, never at `initialize`. A slow or
+  malformed file can no longer block startup or the per-file features (hover,
+  completion, diagnostics).
+- **Tree-sitter grammar refreshed** for the current syntax (`comptime`,
+  `yield`, `is`, hex/octal/binary integer literals, `||=`/`&&=`), and the
+  parser is generated at ABI 14 for editor compatibility (e.g. Neovim 0.10).
+
+### Internal
+
+- The LSP protocol test suite was expanded substantially: response wire-shape
+  assertions (numeric enum codes, unwrapped `documentChanges`, result-XOR-error
+  envelopes), exact 0↔1-indexed coordinate encoding for rename/references/
+  prepare-rename, robustness cases (out-of-bounds positions, unknown methods,
+  duplicate `initialize`, malformed bodies, never-opened documents), and the
+  diagnostics-clear-on-fix lifecycle. `zig build test` is now 126 tests.
+
 ## [0.8.0] - 2026-09-04
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -72,6 +72,11 @@ Version numbers follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.
   pointing at the source, instead of exiting silently.
 - **Missing executable** reports `command not found: '<name>'` with the call's
   source location, instead of a bare `error.FileNotFound`.
+- **Lexer infinite loop on a lone `$` in a string** — a `$` inside a string
+  that does not begin a `${…}` interpolation (e.g. `"$r"`, `"cost: $5"`) is now
+  literal text; it previously spun forever because the character was never
+  consumed. This hung both the CLI and the LSP (whose workspace scan parses
+  every file at startup).
 - **LSP stability** — the workspace type checker's analysis memory is now reset
   each edit (it previously grew unboundedly); the per-edit re-check is bounded
   to the open documents rather than every module ever touched; and a

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -130,6 +130,22 @@ Current concerns:
   remaining open set so those references are dropped and rebuilt. Regression
   tests in `tests/lsp_protocol.zig` cover close-then-request on an importer and
   repeated open/change/close/reopen churn.
+- request-level crash resilience — **addressed (0.8.1):** a position past
+  end-of-file (a line beyond the document, or a character past a line's end)
+  ran the position→offset scan off the buffer and crashed the server; such a
+  position now resolves to nothing. A malformed request body previously
+  propagated an error out of the main loop and ended the session; it is now
+  logged and dropped, and the session continues. Both are regression-tested,
+  alongside unknown-method (`-32601`) and duplicate-`initialize` (`-32600`)
+  handling and navigation requests against never-opened documents.
+- protocol wire-shape correctness — **addressed (0.8.1):** outgoing enums
+  serialize as their numeric codes and single-variant unions
+  (`documentChanges`, capability `Either`s) unwrap to bare objects rather than
+  tag-wrapped envelopes — a rename/code-action edit that clients rejected is
+  fixed, and the remaining latent cases (`InsertTextMode`, `CompletionItemTag`,
+  `ProgressToken`) are guarded. Responses use JSON-RPC result-XOR-error form.
+  Covered by unit tests in `src/lsp/types.zig` and wire-shape assertions in
+  `tests/lsp_protocol.zig`.
 
 ### 4. Better alignment with the language pipeline
 

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -37,9 +37,12 @@ Today it provides:
 - prepare-rename (validates the rename target and pre-fills the identifier)
 - code actions (quick fix: add an inferred type annotation to a binding)
 - workspace symbol search across all indexed files
-- a workspace index: on initialize with a client-provided root, every `.rn`
-  file is loaded into the document store, making navigation work across files
-  that are not open
+- a workspace index: the first workspace-wide request (symbol search,
+  references, rename, cross-file definition) with a client-provided root loads
+  every `.rn` file into the document store, making navigation work across files
+  that are not open. The scan is lazy — it never runs at initialize — so a slow
+  or malformed file can only ever affect that first request, not startup or the
+  per-file features (hover, completion, diagnostics)
 
 There is also a placeholder `--tcp <port>` flag in the CLI surface, but that
 transport is still reserved rather than being part of the supported workflow.
@@ -93,10 +96,10 @@ Current planned work:
   never opened (type-checked on demand for the request); unresolvable symbols
   (commands, unbound names) fall back to a lexical name match
 - ~~more reliable identifier-to-symbol resolution~~ / workspace-wide
-  navigation — **done for definition:** the workspace is indexed on
-  initialize (client-provided roots only, never the cwd fallback), so
-  go-to-definition and references resolve to declarations in files that were
-  never opened; workspace/symbol search is served from the same index
+  navigation — **done:** the workspace is indexed lazily on the first
+  workspace-wide request (client-provided roots only, never the cwd fallback),
+  so go-to-definition, references, and rename resolve to declarations in files
+  that were never opened; workspace/symbol search is served from the same index
 - ~~possibly document links where they clearly help navigation~~ **done:**
   `import "./x.rn"` paths are links to the module file (embedded `std`
   imports are skipped, having no file to open)

--- a/editor/neovim/tree-sitter/grammar.js
+++ b/editor/neovim/tree-sitter/grammar.js
@@ -95,10 +95,10 @@ module.exports = grammar({
       // $.heredoc_fence
     ),
 
-    keyword_declaration: _ => choice('const', 'var', 'fn', 'pub'),
+    keyword_declaration: _ => choice('const', 'var', 'fn', 'pub', 'comptime'),
     keyword_type: _ => choice('error', 'enum', 'union', 'struct'),
     keyword_async: _ => choice('async', 'await'),
-    keyword_control: _ => choice('if', 'else', 'match', 'return', 'exit'),
+    keyword_control: _ => choice('if', 'else', 'match', 'exit', 'yield', 'is'),
     keyword_loop: _ => choice('for', 'while'),
     keyword_import: _ => 'import',
     keyword_interop: _ => 'bash',
@@ -110,6 +110,8 @@ module.exports = grammar({
 
     number_literal: _ => token(choice(
       seq(/0[xX]/, /[0-9a-fA-F_]+/),
+      seq(/0[oO]/, /[0-7_]+/),
+      seq(/0[bB]/, /[01_]+/),
       seq(
         /\d+(_\d+)*/,
         optional(seq('.', /\d+(_\d+)*/)),
@@ -278,7 +280,7 @@ module.exports = grammar({
       '>'
     )),
 
-    assignment_operator: _ => token(choice('+=', '-=', '*=', '/=', '%=', '=')),
+    assignment_operator: _ => token(choice('+=', '-=', '*=', '/=', '%=', '||=', '&&=', '=')),
 
     range_operator: _ => choice('..', '...'),
 

--- a/editor/neovim/tree-sitter/src/grammar.json
+++ b/editor/neovim/tree-sitter/src/grammar.json
@@ -288,6 +288,10 @@
         {
           "type": "STRING",
           "value": "pub"
+        },
+        {
+          "type": "STRING",
+          "value": "comptime"
         }
       ]
     },
@@ -342,11 +346,15 @@
         },
         {
           "type": "STRING",
-          "value": "return"
+          "value": "exit"
         },
         {
           "type": "STRING",
-          "value": "exit"
+          "value": "yield"
+        },
+        {
+          "type": "STRING",
+          "value": "is"
         }
       ]
     },
@@ -424,6 +432,32 @@
               {
                 "type": "PATTERN",
                 "value": "[0-9a-fA-F_]+"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "0[oO]"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[0-7_]+"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "PATTERN",
+                "value": "0[bB]"
+              },
+              {
+                "type": "PATTERN",
+                "value": "[01_]+"
               }
             ]
           },
@@ -1169,6 +1203,14 @@
           {
             "type": "STRING",
             "value": "%="
+          },
+          {
+            "type": "STRING",
+            "value": "||="
+          },
+          {
+            "type": "STRING",
+            "value": "&&="
           },
           {
             "type": "STRING",

--- a/editor/neovim/tree-sitter/src/node-types.json
+++ b/editor/neovim/tree-sitter/src/node-types.json
@@ -1070,6 +1070,10 @@
     "named": true
   },
   {
+    "type": "comptime",
+    "named": false
+  },
+  {
     "type": "const",
     "named": false
   },
@@ -1122,6 +1126,10 @@
     "named": false
   },
   {
+    "type": "is",
+    "named": false
+  },
+  {
     "type": "keyword_import",
     "named": true
   },
@@ -1167,10 +1175,6 @@
     "named": false
   },
   {
-    "type": "return",
-    "named": false
-  },
-  {
     "type": "stage_separator",
     "named": true
   },
@@ -1208,6 +1212,10 @@
   },
   {
     "type": "while",
+    "named": false
+  },
+  {
+    "type": "yield",
     "named": false
   },
   {

--- a/editor/neovim/tree-sitter/src/parser.c
+++ b/editor/neovim/tree-sitter/src/parser.c
@@ -6,12 +6,12 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
-#define LANGUAGE_VERSION 14
+#define LANGUAGE_VERSION 15
 #define STATE_COUNT 138
 #define LARGE_STATE_COUNT 97
-#define SYMBOL_COUNT 111
+#define SYMBOL_COUNT 113
 #define ALIAS_COUNT 0
-#define TOKEN_COUNT 75
+#define TOKEN_COUNT 77
 #define EXTERNAL_TOKEN_COUNT 0
 #define FIELD_COUNT 0
 #define MAX_ALIAS_SEQUENCE_LENGTH 3
@@ -25,111 +25,113 @@ enum ts_symbol_identifiers {
   anon_sym_var = 3,
   anon_sym_fn = 4,
   anon_sym_pub = 5,
-  anon_sym_error = 6,
-  anon_sym_enum = 7,
-  anon_sym_union = 8,
-  anon_sym_struct = 9,
-  anon_sym_async = 10,
-  anon_sym_await = 11,
-  anon_sym_if = 12,
-  anon_sym_else = 13,
-  anon_sym_match = 14,
-  anon_sym_return = 15,
+  anon_sym_comptime = 6,
+  anon_sym_error = 7,
+  anon_sym_enum = 8,
+  anon_sym_union = 9,
+  anon_sym_struct = 10,
+  anon_sym_async = 11,
+  anon_sym_await = 12,
+  anon_sym_if = 13,
+  anon_sym_else = 14,
+  anon_sym_match = 15,
   anon_sym_exit = 16,
-  anon_sym_for = 17,
-  anon_sym_while = 18,
-  sym_keyword_import = 19,
-  sym_keyword_interop = 20,
-  anon_sym_try = 21,
-  anon_sym_catch = 22,
-  anon_sym_orelse = 23,
-  anon_sym_true = 24,
-  anon_sym_false = 25,
-  sym_null_literal = 26,
-  sym_number_literal = 27,
-  anon_sym_DQUOTE = 28,
-  sym_string_fragment = 29,
-  sym_escape_sequence = 30,
-  anon_sym_DOLLAR_LBRACE = 31,
-  anon_sym_RBRACE = 32,
-  anon_sym_LPAREN = 33,
-  anon_sym_RPAREN = 34,
-  anon_sym_LBRACK = 35,
-  anon_sym_RBRACK = 36,
-  anon_sym_LBRACE = 37,
-  anon_sym_SQUOTE = 38,
-  aux_sym_rune_literal_token1 = 39,
-  anon_sym_PIPE = 40,
-  anon_sym_COMMA = 41,
-  anon_sym__ = 42,
-  anon_sym_cd = 43,
-  anon_sym_echo = 44,
-  anon_sym_inspect = 45,
-  anon_sym_lower = 46,
-  anon_sym_upper = 47,
-  sym_type_identifier = 48,
-  anon_sym_AMP = 49,
-  sym_process_operator = 50,
-  sym_logical_operator = 51,
-  sym_comparison_operator = 52,
-  sym_assignment_operator = 53,
-  anon_sym_DOT_DOT = 54,
-  anon_sym_DOT_DOT_DOT = 55,
-  anon_sym_DASH_GT = 56,
-  anon_sym_EQ_GT = 57,
-  anon_sym_DOLLAR = 58,
-  anon_sym_QMARK = 59,
-  anon_sym_CARET = 60,
-  anon_sym_BANG = 61,
-  anon_sym_DOLLAR_LPAREN = 62,
-  anon_sym_DOT_LBRACE = 63,
-  anon_sym_COLON = 64,
-  anon_sym_DOT = 65,
-  sym_command_head = 66,
-  sym_stage_separator = 67,
-  aux_sym_documentation_comment_token1 = 68,
-  anon_sym_SLASH_STAR_STAR = 69,
-  aux_sym_documentation_comment_token2 = 70,
-  aux_sym_documentation_comment_token3 = 71,
-  anon_sym_STAR_SLASH = 72,
-  sym_line_comment = 73,
-  anon_sym_SLASH_STAR = 74,
-  sym_source_file = 75,
-  sym_command = 76,
-  sym__argument = 77,
-  sym__expression_atom = 78,
-  sym_keyword_declaration = 79,
-  sym_keyword_type = 80,
-  sym_keyword_async = 81,
-  sym_keyword_control = 82,
-  sym_keyword_loop = 83,
-  sym_keyword_try = 84,
-  sym_boolean_literal = 85,
-  sym_string_literal = 86,
-  sym_interpolation_expression = 87,
-  sym__interpolation_atom = 88,
-  sym_interpolation_paren_group = 89,
-  sym_interpolation_bracket_group = 90,
-  sym_interpolation_brace_group = 91,
-  sym_rune_literal = 92,
-  sym_capture_clause = 93,
-  sym__capture_bindings = 94,
-  sym__capture_binding = 95,
-  sym_builtin_command = 96,
-  sym_pipeline_operator = 97,
-  sym_range_operator = 98,
-  sym_arrow_operator = 99,
-  sym_sigil = 100,
-  sym_bracket = 101,
-  sym_punctuation_delimiter = 102,
-  sym_documentation_comment = 103,
-  sym_block_comment = 104,
-  aux_sym_source_file_repeat1 = 105,
-  aux_sym_command_repeat1 = 106,
-  aux_sym_string_literal_repeat1 = 107,
-  aux_sym_interpolation_expression_repeat1 = 108,
-  aux_sym__capture_bindings_repeat1 = 109,
-  aux_sym_documentation_comment_repeat1 = 110,
+  anon_sym_yield = 17,
+  anon_sym_is = 18,
+  anon_sym_for = 19,
+  anon_sym_while = 20,
+  sym_keyword_import = 21,
+  sym_keyword_interop = 22,
+  anon_sym_try = 23,
+  anon_sym_catch = 24,
+  anon_sym_orelse = 25,
+  anon_sym_true = 26,
+  anon_sym_false = 27,
+  sym_null_literal = 28,
+  sym_number_literal = 29,
+  anon_sym_DQUOTE = 30,
+  sym_string_fragment = 31,
+  sym_escape_sequence = 32,
+  anon_sym_DOLLAR_LBRACE = 33,
+  anon_sym_RBRACE = 34,
+  anon_sym_LPAREN = 35,
+  anon_sym_RPAREN = 36,
+  anon_sym_LBRACK = 37,
+  anon_sym_RBRACK = 38,
+  anon_sym_LBRACE = 39,
+  anon_sym_SQUOTE = 40,
+  aux_sym_rune_literal_token1 = 41,
+  anon_sym_PIPE = 42,
+  anon_sym_COMMA = 43,
+  anon_sym__ = 44,
+  anon_sym_cd = 45,
+  anon_sym_echo = 46,
+  anon_sym_inspect = 47,
+  anon_sym_lower = 48,
+  anon_sym_upper = 49,
+  sym_type_identifier = 50,
+  anon_sym_AMP = 51,
+  sym_process_operator = 52,
+  sym_logical_operator = 53,
+  sym_comparison_operator = 54,
+  sym_assignment_operator = 55,
+  anon_sym_DOT_DOT = 56,
+  anon_sym_DOT_DOT_DOT = 57,
+  anon_sym_DASH_GT = 58,
+  anon_sym_EQ_GT = 59,
+  anon_sym_DOLLAR = 60,
+  anon_sym_QMARK = 61,
+  anon_sym_CARET = 62,
+  anon_sym_BANG = 63,
+  anon_sym_DOLLAR_LPAREN = 64,
+  anon_sym_DOT_LBRACE = 65,
+  anon_sym_COLON = 66,
+  anon_sym_DOT = 67,
+  sym_command_head = 68,
+  sym_stage_separator = 69,
+  aux_sym_documentation_comment_token1 = 70,
+  anon_sym_SLASH_STAR_STAR = 71,
+  aux_sym_documentation_comment_token2 = 72,
+  aux_sym_documentation_comment_token3 = 73,
+  anon_sym_STAR_SLASH = 74,
+  sym_line_comment = 75,
+  anon_sym_SLASH_STAR = 76,
+  sym_source_file = 77,
+  sym_command = 78,
+  sym__argument = 79,
+  sym__expression_atom = 80,
+  sym_keyword_declaration = 81,
+  sym_keyword_type = 82,
+  sym_keyword_async = 83,
+  sym_keyword_control = 84,
+  sym_keyword_loop = 85,
+  sym_keyword_try = 86,
+  sym_boolean_literal = 87,
+  sym_string_literal = 88,
+  sym_interpolation_expression = 89,
+  sym__interpolation_atom = 90,
+  sym_interpolation_paren_group = 91,
+  sym_interpolation_bracket_group = 92,
+  sym_interpolation_brace_group = 93,
+  sym_rune_literal = 94,
+  sym_capture_clause = 95,
+  sym__capture_bindings = 96,
+  sym__capture_binding = 97,
+  sym_builtin_command = 98,
+  sym_pipeline_operator = 99,
+  sym_range_operator = 100,
+  sym_arrow_operator = 101,
+  sym_sigil = 102,
+  sym_bracket = 103,
+  sym_punctuation_delimiter = 104,
+  sym_documentation_comment = 105,
+  sym_block_comment = 106,
+  aux_sym_source_file_repeat1 = 107,
+  aux_sym_command_repeat1 = 108,
+  aux_sym_string_literal_repeat1 = 109,
+  aux_sym_interpolation_expression_repeat1 = 110,
+  aux_sym__capture_bindings_repeat1 = 111,
+  aux_sym_documentation_comment_repeat1 = 112,
 };
 
 static const char * const ts_symbol_names[] = {
@@ -139,6 +141,7 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_var] = "var",
   [anon_sym_fn] = "fn",
   [anon_sym_pub] = "pub",
+  [anon_sym_comptime] = "comptime",
   [anon_sym_error] = "error",
   [anon_sym_enum] = "enum",
   [anon_sym_union] = "union",
@@ -148,8 +151,9 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_if] = "if",
   [anon_sym_else] = "else",
   [anon_sym_match] = "match",
-  [anon_sym_return] = "return",
   [anon_sym_exit] = "exit",
+  [anon_sym_yield] = "yield",
+  [anon_sym_is] = "is",
   [anon_sym_for] = "for",
   [anon_sym_while] = "while",
   [sym_keyword_import] = "keyword_import",
@@ -253,6 +257,7 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_var] = anon_sym_var,
   [anon_sym_fn] = anon_sym_fn,
   [anon_sym_pub] = anon_sym_pub,
+  [anon_sym_comptime] = anon_sym_comptime,
   [anon_sym_error] = anon_sym_error,
   [anon_sym_enum] = anon_sym_enum,
   [anon_sym_union] = anon_sym_union,
@@ -262,8 +267,9 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_if] = anon_sym_if,
   [anon_sym_else] = anon_sym_else,
   [anon_sym_match] = anon_sym_match,
-  [anon_sym_return] = anon_sym_return,
   [anon_sym_exit] = anon_sym_exit,
+  [anon_sym_yield] = anon_sym_yield,
+  [anon_sym_is] = anon_sym_is,
   [anon_sym_for] = anon_sym_for,
   [anon_sym_while] = anon_sym_while,
   [sym_keyword_import] = sym_keyword_import,
@@ -385,6 +391,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [anon_sym_comptime] = {
+    .visible = true,
+    .named = false,
+  },
   [anon_sym_error] = {
     .visible = true,
     .named = false,
@@ -421,11 +431,15 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym_return] = {
+  [anon_sym_exit] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym_exit] = {
+  [anon_sym_yield] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_is] = {
     .visible = true,
     .named = false,
   },
@@ -961,730 +975,757 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(25);
+      if (eof) ADVANCE(27);
       ADVANCE_MAP(
-        '!', 77,
-        '"', 32,
-        '#', 104,
-        '$', 74,
+        '!', 81,
+        '"', 36,
+        '#', 108,
+        '$', 78,
         '%', 9,
-        '&', 59,
-        '\'', 50,
-        '(', 45,
-        ')', 46,
+        '&', 63,
+        '\'', 54,
+        '(', 49,
+        ')', 50,
         '*', 7,
         '+', 9,
-        ',', 56,
+        ',', 60,
         '-', 10,
-        '.', 82,
-        '/', 83,
-        '0', 26,
-        ':', 80,
-        ';', 90,
-        '<', 66,
-        '=', 68,
-        '>', 61,
-        '?', 75,
-        '[', 47,
+        '.', 86,
+        '/', 87,
+        '0', 28,
+        ':', 84,
+        ';', 94,
+        '<', 70,
+        '=', 72,
+        '>', 65,
+        '?', 79,
+        '[', 51,
         '\\', 11,
-        ']', 48,
-        '^', 76,
-        'a', 87,
-        'o', 88,
-        '{', 49,
-        '|', 55,
-        '}', 44,
+        ']', 52,
+        '^', 80,
+        'a', 91,
+        'o', 92,
+        '{', 53,
+        '|', 59,
+        '}', 48,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(24);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(27);
+          lookahead == ' ') SKIP(26);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(29);
       if (lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(89);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(58);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(93);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(62);
       END_STATE();
     case 1:
       ADVANCE_MAP(
-        '!', 77,
-        '"', 32,
-        '#', 104,
-        '$', 73,
+        '!', 81,
+        '"', 36,
+        '#', 108,
+        '$', 77,
         '%', 9,
-        '&', 59,
-        '\'', 50,
-        '(', 45,
-        ')', 46,
+        '&', 63,
+        '\'', 54,
+        '(', 49,
+        ')', 50,
         '*', 9,
         '+', 9,
-        ',', 56,
+        ',', 60,
         '-', 10,
-        '.', 81,
-        '/', 83,
-        '0', 26,
-        ':', 80,
-        ';', 90,
-        '<', 66,
-        '=', 68,
-        '>', 61,
-        '?', 75,
-        '[', 47,
-        ']', 48,
-        '^', 76,
-        'a', 87,
-        'o', 88,
-        '{', 49,
-        '|', 55,
-        '}', 44,
+        '.', 85,
+        '/', 87,
+        '0', 28,
+        ':', 84,
+        ';', 94,
+        '<', 70,
+        '=', 72,
+        '>', 65,
+        '?', 79,
+        '[', 51,
+        ']', 52,
+        '^', 80,
+        'a', 91,
+        'o', 92,
+        '{', 53,
+        '|', 59,
+        '}', 48,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(1);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(27);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(29);
       if (lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(89);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(58);
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(93);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(62);
       END_STATE();
     case 2:
-      if (lookahead == '"') ADVANCE(32);
-      if (lookahead == '#') ADVANCE(34);
+      if (lookahead == '"') ADVANCE(36);
+      if (lookahead == '#') ADVANCE(38);
       if (lookahead == '$') ADVANCE(12);
-      if (lookahead == '/') ADVANCE(37);
+      if (lookahead == '/') ADVANCE(41);
       if (lookahead == '\\') ADVANCE(11);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(36);
-      if (lookahead != 0) ADVANCE(38);
+          lookahead == ' ') ADVANCE(40);
+      if (lookahead != 0) ADVANCE(42);
       END_STATE();
     case 3:
-      if (lookahead == '#') ADVANCE(104);
-      if (lookahead == ',') ADVANCE(56);
+      if (lookahead == '#') ADVANCE(108);
+      if (lookahead == ',') ADVANCE(60);
       if (lookahead == '/') ADVANCE(6);
-      if (lookahead == '|') ADVANCE(54);
+      if (lookahead == '|') ADVANCE(58);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(3);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
       END_STATE();
     case 4:
-      if (lookahead == '#') ADVANCE(98);
+      if (lookahead == '#') ADVANCE(102);
       if (lookahead == '*') ADVANCE(8);
-      if (lookahead == '/') ADVANCE(97);
+      if (lookahead == '/') ADVANCE(101);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(96);
-      if (lookahead != 0) ADVANCE(95);
+          lookahead == ' ') ADVANCE(100);
+      if (lookahead != 0) ADVANCE(99);
       END_STATE();
     case 5:
-      if (lookahead == '#') ADVANCE(53);
-      if (lookahead == '/') ADVANCE(52);
+      if (lookahead == '#') ADVANCE(57);
+      if (lookahead == '/') ADVANCE(56);
       if (lookahead == '\\') ADVANCE(11);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(51);
+          lookahead == ' ') ADVANCE(55);
       if (lookahead != 0 &&
-          lookahead != '\'') ADVANCE(51);
+          lookahead != '\'') ADVANCE(55);
       END_STATE();
     case 6:
-      if (lookahead == '*') ADVANCE(105);
-      if (lookahead == '/') ADVANCE(102);
+      if (lookahead == '*') ADVANCE(109);
+      if (lookahead == '/') ADVANCE(106);
       END_STATE();
     case 7:
-      if (lookahead == '/') ADVANCE(100);
-      if (lookahead == '=') ADVANCE(67);
-      if (lookahead != 0) ADVANCE(99);
+      if (lookahead == '/') ADVANCE(104);
+      if (lookahead == '=') ADVANCE(71);
+      if (lookahead != 0) ADVANCE(103);
       END_STATE();
     case 8:
-      if (lookahead == '/') ADVANCE(100);
-      if (lookahead != 0) ADVANCE(99);
+      if (lookahead == '/') ADVANCE(104);
+      if (lookahead != 0) ADVANCE(103);
       END_STATE();
     case 9:
-      if (lookahead == '=') ADVANCE(67);
+      if (lookahead == '=') ADVANCE(71);
       END_STATE();
     case 10:
-      if (lookahead == '=') ADVANCE(67);
-      if (lookahead == '>') ADVANCE(71);
+      if (lookahead == '=') ADVANCE(71);
+      if (lookahead == '>') ADVANCE(75);
       END_STATE();
     case 11:
-      if (lookahead == 'u') ADVANCE(41);
-      if (lookahead == 'x') ADVANCE(42);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(40);
+      if (lookahead == 'u') ADVANCE(45);
+      if (lookahead == 'x') ADVANCE(46);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(44);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(39);
+          lookahead != '\n') ADVANCE(43);
       END_STATE();
     case 12:
-      if (lookahead == '{') ADVANCE(43);
+      if (lookahead == '{') ADVANCE(47);
       END_STATE();
     case 13:
       if (lookahead == '+' ||
-          lookahead == '-') ADVANCE(18);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(30);
+          lookahead == '-') ADVANCE(20);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(32);
       END_STATE();
     case 14:
       if (lookahead == '!' ||
           lookahead == '?' ||
           lookahead == '^') ADVANCE(14);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(57);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(61);
       END_STATE();
     case 15:
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(39);
+      if (lookahead == '0' ||
+          lookahead == '1' ||
+          lookahead == '_') ADVANCE(33);
       END_STATE();
     case 16:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(29);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(43);
       END_STATE();
     case 17:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(28);
+      if (('0' <= lookahead && lookahead <= '7') ||
+          lookahead == '_') ADVANCE(34);
       END_STATE();
     case 18:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(30);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(31);
       END_STATE();
     case 19:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(39);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(30);
       END_STATE();
     case 20:
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(19);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(32);
       END_STATE();
     case 21:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(20);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(43);
       END_STATE();
     case 22:
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(31);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(21);
       END_STATE();
     case 23:
-      if (eof) ADVANCE(25);
-      ADVANCE_MAP(
-        '!', 77,
-        '"', 32,
-        '#', 104,
-        '$', 74,
-        '%', 9,
-        '&', 59,
-        '\'', 50,
-        '(', 45,
-        ')', 46,
-        '*', 9,
-        '+', 9,
-        ',', 56,
-        '-', 10,
-        '.', 82,
-        '/', 83,
-        '0', 26,
-        ':', 80,
-        ';', 90,
-        '<', 66,
-        '=', 68,
-        '>', 61,
-        '?', 75,
-        '[', 47,
-        ']', 48,
-        '^', 76,
-        'a', 87,
-        'o', 88,
-        '{', 49,
-        '|', 55,
-        '}', 44,
-      );
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(23);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(27);
-      if (lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(89);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(58);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(22);
       END_STATE();
     case 24:
-      if (eof) ADVANCE(25);
-      ADVANCE_MAP(
-        '!', 77,
-        '"', 32,
-        '#', 104,
-        '$', 74,
-        '%', 9,
-        '&', 59,
-        '\'', 50,
-        '(', 45,
-        ')', 46,
-        '*', 7,
-        '+', 9,
-        ',', 56,
-        '-', 10,
-        '.', 82,
-        '/', 83,
-        '0', 26,
-        ':', 80,
-        ';', 90,
-        '<', 66,
-        '=', 68,
-        '>', 61,
-        '?', 75,
-        '[', 47,
-        ']', 48,
-        '^', 76,
-        'a', 87,
-        'o', 88,
-        '{', 49,
-        '|', 55,
-        '}', 44,
-      );
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') SKIP(24);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(27);
-      if (lookahead == '_' ||
-          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(89);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(58);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(35);
       END_STATE();
     case 25:
-      ACCEPT_TOKEN(ts_builtin_sym_end);
+      if (eof) ADVANCE(27);
+      ADVANCE_MAP(
+        '!', 81,
+        '"', 36,
+        '#', 108,
+        '$', 78,
+        '%', 9,
+        '&', 63,
+        '\'', 54,
+        '(', 49,
+        ')', 50,
+        '*', 9,
+        '+', 9,
+        ',', 60,
+        '-', 10,
+        '.', 86,
+        '/', 87,
+        '0', 28,
+        ':', 84,
+        ';', 94,
+        '<', 70,
+        '=', 72,
+        '>', 65,
+        '?', 79,
+        '[', 51,
+        ']', 52,
+        '^', 80,
+        'a', 91,
+        'o', 92,
+        '{', 53,
+        '|', 59,
+        '}', 48,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(25);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(29);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(93);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(62);
       END_STATE();
     case 26:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(16);
-      if (lookahead == '>') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(17);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(13);
-      if (lookahead == 'X' ||
-          lookahead == 'x') ADVANCE(22);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(27);
+      if (eof) ADVANCE(27);
+      ADVANCE_MAP(
+        '!', 81,
+        '"', 36,
+        '#', 108,
+        '$', 78,
+        '%', 9,
+        '&', 63,
+        '\'', 54,
+        '(', 49,
+        ')', 50,
+        '*', 7,
+        '+', 9,
+        ',', 60,
+        '-', 10,
+        '.', 86,
+        '/', 87,
+        '0', 28,
+        ':', 84,
+        ';', 94,
+        '<', 70,
+        '=', 72,
+        '>', 65,
+        '?', 79,
+        '[', 51,
+        ']', 52,
+        '^', 80,
+        'a', 91,
+        'o', 92,
+        '{', 53,
+        '|', 59,
+        '}', 48,
+      );
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') SKIP(26);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(29);
+      if (lookahead == '_' ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(93);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(62);
       END_STATE();
     case 27:
-      ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(16);
-      if (lookahead == '>') ADVANCE(62);
-      if (lookahead == '_') ADVANCE(17);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(13);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(27);
+      ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
     case 28:
       ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '.') ADVANCE(16);
-      if (lookahead == '_') ADVANCE(17);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(13);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(28);
+      ADVANCE_MAP(
+        '.', 18,
+        '>', 66,
+        '_', 19,
+        'B', 15,
+        'b', 15,
+        'E', 13,
+        'e', 13,
+        'O', 17,
+        'o', 17,
+        'X', 24,
+        'x', 24,
+      );
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(29);
       END_STATE();
     case 29:
       ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '_') ADVANCE(16);
+      if (lookahead == '.') ADVANCE(18);
+      if (lookahead == '>') ADVANCE(66);
+      if (lookahead == '_') ADVANCE(19);
       if (lookahead == 'E' ||
           lookahead == 'e') ADVANCE(13);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(29);
       END_STATE();
     case 30:
       ACCEPT_TOKEN(sym_number_literal);
-      if (lookahead == '_') ADVANCE(18);
+      if (lookahead == '.') ADVANCE(18);
+      if (lookahead == '_') ADVANCE(19);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(13);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(30);
       END_STATE();
     case 31:
       ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '_') ADVANCE(18);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(13);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(31);
+      END_STATE();
+    case 32:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '_') ADVANCE(20);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(32);
+      END_STATE();
+    case 33:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (lookahead == '0' ||
+          lookahead == '1' ||
+          lookahead == '_') ADVANCE(33);
+      END_STATE();
+    case 34:
+      ACCEPT_TOKEN(sym_number_literal);
+      if (('0' <= lookahead && lookahead <= '7') ||
+          lookahead == '_') ADVANCE(34);
+      END_STATE();
+    case 35:
+      ACCEPT_TOKEN(sym_number_literal);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(31);
-      END_STATE();
-    case 32:
-      ACCEPT_TOKEN(anon_sym_DQUOTE);
-      END_STATE();
-    case 33:
-      ACCEPT_TOKEN(sym_string_fragment);
-      if (lookahead == '\n') ADVANCE(38);
-      if (lookahead == '/') ADVANCE(35);
-      if (lookahead == '"' ||
-          lookahead == '$' ||
-          lookahead == '\\') ADVANCE(104);
-      if (lookahead != 0) ADVANCE(34);
-      END_STATE();
-    case 34:
-      ACCEPT_TOKEN(sym_string_fragment);
-      if (lookahead == '\n') ADVANCE(38);
-      if (lookahead == '"' ||
-          lookahead == '$' ||
-          lookahead == '\\') ADVANCE(104);
-      if (lookahead != 0) ADVANCE(34);
-      END_STATE();
-    case 35:
-      ACCEPT_TOKEN(sym_string_fragment);
-      if (lookahead == '\n') ADVANCE(38);
-      if (lookahead == '"' ||
-          lookahead == '$' ||
-          lookahead == '\\') ADVANCE(92);
-      if (lookahead != 0) ADVANCE(35);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(35);
       END_STATE();
     case 36:
-      ACCEPT_TOKEN(sym_string_fragment);
-      if (lookahead == '#') ADVANCE(34);
-      if (lookahead == '/') ADVANCE(37);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(36);
-      if (lookahead != 0 &&
-          (lookahead < '"' || '$' < lookahead) &&
-          lookahead != '\\') ADVANCE(38);
+      ACCEPT_TOKEN(anon_sym_DQUOTE);
       END_STATE();
     case 37:
       ACCEPT_TOKEN(sym_string_fragment);
-      if (lookahead == '*') ADVANCE(106);
-      if (lookahead == '/') ADVANCE(33);
+      if (lookahead == '\n') ADVANCE(42);
+      if (lookahead == '/') ADVANCE(39);
+      if (lookahead == '"' ||
+          lookahead == '$' ||
+          lookahead == '\\') ADVANCE(108);
+      if (lookahead != 0) ADVANCE(38);
+      END_STATE();
+    case 38:
+      ACCEPT_TOKEN(sym_string_fragment);
+      if (lookahead == '\n') ADVANCE(42);
+      if (lookahead == '"' ||
+          lookahead == '$' ||
+          lookahead == '\\') ADVANCE(108);
+      if (lookahead != 0) ADVANCE(38);
+      END_STATE();
+    case 39:
+      ACCEPT_TOKEN(sym_string_fragment);
+      if (lookahead == '\n') ADVANCE(42);
+      if (lookahead == '"' ||
+          lookahead == '$' ||
+          lookahead == '\\') ADVANCE(96);
+      if (lookahead != 0) ADVANCE(39);
+      END_STATE();
+    case 40:
+      ACCEPT_TOKEN(sym_string_fragment);
+      if (lookahead == '#') ADVANCE(38);
+      if (lookahead == '/') ADVANCE(41);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(40);
+      if (lookahead != 0 &&
+          (lookahead < '"' || '$' < lookahead) &&
+          lookahead != '\\') ADVANCE(42);
+      END_STATE();
+    case 41:
+      ACCEPT_TOKEN(sym_string_fragment);
+      if (lookahead == '*') ADVANCE(110);
+      if (lookahead == '/') ADVANCE(37);
       if (lookahead != 0 &&
           lookahead != '"' &&
           lookahead != '$' &&
-          lookahead != '\\') ADVANCE(38);
+          lookahead != '\\') ADVANCE(42);
       END_STATE();
-    case 38:
+    case 42:
       ACCEPT_TOKEN(sym_string_fragment);
       if (lookahead != 0 &&
           lookahead != '"' &&
           lookahead != '$' &&
-          lookahead != '\\') ADVANCE(38);
+          lookahead != '\\') ADVANCE(42);
       END_STATE();
-    case 39:
+    case 43:
       ACCEPT_TOKEN(sym_escape_sequence);
       END_STATE();
-    case 40:
+    case 44:
       ACCEPT_TOKEN(sym_escape_sequence);
-      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(15);
+      if (('0' <= lookahead && lookahead <= '7')) ADVANCE(16);
       END_STATE();
-    case 41:
+    case 45:
+      ACCEPT_TOKEN(sym_escape_sequence);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'F') ||
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(23);
+      END_STATE();
+    case 46:
       ACCEPT_TOKEN(sym_escape_sequence);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(21);
       END_STATE();
-    case 42:
-      ACCEPT_TOKEN(sym_escape_sequence);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(19);
-      END_STATE();
-    case 43:
+    case 47:
       ACCEPT_TOKEN(anon_sym_DOLLAR_LBRACE);
       END_STATE();
-    case 44:
+    case 48:
       ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
-    case 45:
+    case 49:
       ACCEPT_TOKEN(anon_sym_LPAREN);
       END_STATE();
-    case 46:
+    case 50:
       ACCEPT_TOKEN(anon_sym_RPAREN);
       END_STATE();
-    case 47:
+    case 51:
       ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
-    case 48:
+    case 52:
       ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
-    case 49:
+    case 53:
       ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
-    case 50:
+    case 54:
       ACCEPT_TOKEN(anon_sym_SQUOTE);
       END_STATE();
-    case 51:
-      ACCEPT_TOKEN(aux_sym_rune_literal_token1);
-      END_STATE();
-    case 52:
-      ACCEPT_TOKEN(aux_sym_rune_literal_token1);
-      if (lookahead == '*') ADVANCE(105);
-      if (lookahead == '/') ADVANCE(102);
-      END_STATE();
-    case 53:
-      ACCEPT_TOKEN(aux_sym_rune_literal_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(104);
-      END_STATE();
-    case 54:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      END_STATE();
     case 55:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(63);
+      ACCEPT_TOKEN(aux_sym_rune_literal_token1);
       END_STATE();
     case 56:
-      ACCEPT_TOKEN(anon_sym_COMMA);
+      ACCEPT_TOKEN(aux_sym_rune_literal_token1);
+      if (lookahead == '*') ADVANCE(109);
+      if (lookahead == '/') ADVANCE(106);
       END_STATE();
     case 57:
+      ACCEPT_TOKEN(aux_sym_rune_literal_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(108);
+      END_STATE();
+    case 58:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      END_STATE();
+    case 59:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(67);
+      END_STATE();
+    case 60:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      END_STATE();
+    case 61:
       ACCEPT_TOKEN(sym_type_identifier);
       if (lookahead == '.') ADVANCE(14);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(57);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(61);
       END_STATE();
-    case 58:
+    case 62:
       ACCEPT_TOKEN(sym_type_identifier);
-      if (lookahead == '.') ADVANCE(84);
+      if (lookahead == '.') ADVANCE(88);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(58);
-      END_STATE();
-    case 59:
-      ACCEPT_TOKEN(anon_sym_AMP);
-      if (lookahead == '&') ADVANCE(63);
-      END_STATE();
-    case 60:
-      ACCEPT_TOKEN(sym_process_operator);
-      END_STATE();
-    case 61:
-      ACCEPT_TOKEN(sym_process_operator);
-      if (lookahead == '=') ADVANCE(65);
-      if (lookahead == '&' ||
-          lookahead == '>') ADVANCE(60);
-      END_STATE();
-    case 62:
-      ACCEPT_TOKEN(sym_process_operator);
-      if (lookahead == '&' ||
-          lookahead == '>') ADVANCE(60);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(62);
       END_STATE();
     case 63:
-      ACCEPT_TOKEN(sym_logical_operator);
+      ACCEPT_TOKEN(anon_sym_AMP);
+      if (lookahead == '&') ADVANCE(67);
       END_STATE();
     case 64:
+      ACCEPT_TOKEN(sym_process_operator);
+      END_STATE();
+    case 65:
+      ACCEPT_TOKEN(sym_process_operator);
+      if (lookahead == '=') ADVANCE(69);
+      if (lookahead == '&' ||
+          lookahead == '>') ADVANCE(64);
+      END_STATE();
+    case 66:
+      ACCEPT_TOKEN(sym_process_operator);
+      if (lookahead == '&' ||
+          lookahead == '>') ADVANCE(64);
+      END_STATE();
+    case 67:
+      ACCEPT_TOKEN(sym_logical_operator);
+      if (lookahead == '=') ADVANCE(71);
+      END_STATE();
+    case 68:
       ACCEPT_TOKEN(sym_logical_operator);
       if (lookahead == '-' ||
           ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
-      END_STATE();
-    case 65:
-      ACCEPT_TOKEN(sym_comparison_operator);
-      END_STATE();
-    case 66:
-      ACCEPT_TOKEN(sym_comparison_operator);
-      if (lookahead == '<') ADVANCE(60);
-      if (lookahead == '=') ADVANCE(65);
-      END_STATE();
-    case 67:
-      ACCEPT_TOKEN(sym_assignment_operator);
-      END_STATE();
-    case 68:
-      ACCEPT_TOKEN(sym_assignment_operator);
-      if (lookahead == '=') ADVANCE(65);
-      if (lookahead == '>') ADVANCE(72);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
       END_STATE();
     case 69:
-      ACCEPT_TOKEN(anon_sym_DOT_DOT);
-      if (lookahead == '.') ADVANCE(70);
+      ACCEPT_TOKEN(sym_comparison_operator);
       END_STATE();
     case 70:
-      ACCEPT_TOKEN(anon_sym_DOT_DOT_DOT);
+      ACCEPT_TOKEN(sym_comparison_operator);
+      if (lookahead == '<') ADVANCE(64);
+      if (lookahead == '=') ADVANCE(69);
       END_STATE();
     case 71:
-      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      ACCEPT_TOKEN(sym_assignment_operator);
       END_STATE();
     case 72:
-      ACCEPT_TOKEN(anon_sym_EQ_GT);
+      ACCEPT_TOKEN(sym_assignment_operator);
+      if (lookahead == '=') ADVANCE(69);
+      if (lookahead == '>') ADVANCE(76);
       END_STATE();
     case 73:
-      ACCEPT_TOKEN(anon_sym_DOLLAR);
+      ACCEPT_TOKEN(anon_sym_DOT_DOT);
+      if (lookahead == '.') ADVANCE(74);
       END_STATE();
     case 74:
-      ACCEPT_TOKEN(anon_sym_DOLLAR);
-      if (lookahead == '(') ADVANCE(78);
+      ACCEPT_TOKEN(anon_sym_DOT_DOT_DOT);
       END_STATE();
     case 75:
+      ACCEPT_TOKEN(anon_sym_DASH_GT);
+      END_STATE();
+    case 76:
+      ACCEPT_TOKEN(anon_sym_EQ_GT);
+      END_STATE();
+    case 77:
+      ACCEPT_TOKEN(anon_sym_DOLLAR);
+      END_STATE();
+    case 78:
+      ACCEPT_TOKEN(anon_sym_DOLLAR);
+      if (lookahead == '(') ADVANCE(82);
+      END_STATE();
+    case 79:
       ACCEPT_TOKEN(anon_sym_QMARK);
       if (lookahead == '!' ||
           lookahead == '?' ||
           lookahead == '^') ADVANCE(14);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(57);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(61);
       END_STATE();
-    case 76:
+    case 80:
       ACCEPT_TOKEN(anon_sym_CARET);
       if (lookahead == '!' ||
           lookahead == '?' ||
           lookahead == '^') ADVANCE(14);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(57);
-      END_STATE();
-    case 77:
-      ACCEPT_TOKEN(anon_sym_BANG);
-      if (lookahead == '=') ADVANCE(65);
-      if (lookahead == '!' ||
-          lookahead == '?' ||
-          lookahead == '^') ADVANCE(14);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(57);
-      END_STATE();
-    case 78:
-      ACCEPT_TOKEN(anon_sym_DOLLAR_LPAREN);
-      END_STATE();
-    case 79:
-      ACCEPT_TOKEN(anon_sym_DOT_LBRACE);
-      END_STATE();
-    case 80:
-      ACCEPT_TOKEN(anon_sym_COLON);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(61);
       END_STATE();
     case 81:
-      ACCEPT_TOKEN(anon_sym_DOT);
-      if (lookahead == '.') ADVANCE(69);
-      END_STATE();
-    case 82:
-      ACCEPT_TOKEN(anon_sym_DOT);
-      if (lookahead == '.') ADVANCE(69);
-      if (lookahead == '{') ADVANCE(79);
-      END_STATE();
-    case 83:
-      ACCEPT_TOKEN(sym_command_head);
-      if (lookahead == '*') ADVANCE(105);
-      if (lookahead == '/') ADVANCE(101);
-      if (lookahead == '=') ADVANCE(67);
-      if (('-' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(85);
-      END_STATE();
-    case 84:
-      ACCEPT_TOKEN(sym_command_head);
+      ACCEPT_TOKEN(anon_sym_BANG);
+      if (lookahead == '=') ADVANCE(69);
       if (lookahead == '!' ||
           lookahead == '?' ||
           lookahead == '^') ADVANCE(14);
-      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(58);
-      if (('-' <= lookahead && lookahead <= '9') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(85);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(61);
+      END_STATE();
+    case 82:
+      ACCEPT_TOKEN(anon_sym_DOLLAR_LPAREN);
+      END_STATE();
+    case 83:
+      ACCEPT_TOKEN(anon_sym_DOT_LBRACE);
+      END_STATE();
+    case 84:
+      ACCEPT_TOKEN(anon_sym_COLON);
       END_STATE();
     case 85:
-      ACCEPT_TOKEN(sym_command_head);
-      if (('-' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(85);
+      ACCEPT_TOKEN(anon_sym_DOT);
+      if (lookahead == '.') ADVANCE(73);
       END_STATE();
     case 86:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'd') ADVANCE(64);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
+      ACCEPT_TOKEN(anon_sym_DOT);
+      if (lookahead == '.') ADVANCE(73);
+      if (lookahead == '{') ADVANCE(83);
       END_STATE();
     case 87:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(86);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(sym_command_head);
+      if (lookahead == '*') ADVANCE(109);
+      if (lookahead == '/') ADVANCE(105);
+      if (lookahead == '=') ADVANCE(71);
+      if (('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
       END_STATE();
     case 88:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'r') ADVANCE(64);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
+      ACCEPT_TOKEN(sym_command_head);
+      if (lookahead == '!' ||
+          lookahead == '?' ||
+          lookahead == '^') ADVANCE(14);
+      if (('A' <= lookahead && lookahead <= 'Z')) ADVANCE(62);
+      if (('-' <= lookahead && lookahead <= '9') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
       END_STATE();
     case 89:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '-' ||
-          ('0' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(sym_command_head);
+      if (('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(89);
       END_STATE();
     case 90:
-      ACCEPT_TOKEN(sym_stage_separator);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'd') ADVANCE(68);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
       END_STATE();
     case 91:
-      ACCEPT_TOKEN(aux_sym_documentation_comment_token1);
-      if (('-' <= lookahead && lookahead <= '9') ||
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'n') ADVANCE(90);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(91);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(92);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
       END_STATE();
     case 92:
-      ACCEPT_TOKEN(aux_sym_documentation_comment_token1);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(92);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'r') ADVANCE(68);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
       END_STATE();
     case 93:
-      ACCEPT_TOKEN(anon_sym_SLASH_STAR_STAR);
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(93);
       END_STATE();
     case 94:
+      ACCEPT_TOKEN(sym_stage_separator);
+      END_STATE();
+    case 95:
+      ACCEPT_TOKEN(aux_sym_documentation_comment_token1);
+      if (('-' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(95);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(96);
+      END_STATE();
+    case 96:
+      ACCEPT_TOKEN(aux_sym_documentation_comment_token1);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(96);
+      END_STATE();
+    case 97:
+      ACCEPT_TOKEN(anon_sym_SLASH_STAR_STAR);
+      END_STATE();
+    case 98:
       ACCEPT_TOKEN(anon_sym_SLASH_STAR_STAR);
       if (lookahead != 0 &&
           lookahead != '"' &&
           lookahead != '$' &&
-          lookahead != '\\') ADVANCE(38);
-      END_STATE();
-    case 95:
-      ACCEPT_TOKEN(aux_sym_documentation_comment_token2);
-      END_STATE();
-    case 96:
-      ACCEPT_TOKEN(aux_sym_documentation_comment_token2);
-      if (lookahead == '#') ADVANCE(98);
-      if (lookahead == '/') ADVANCE(97);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(96);
-      if (lookahead != 0 &&
-          lookahead != '*') ADVANCE(95);
-      END_STATE();
-    case 97:
-      ACCEPT_TOKEN(aux_sym_documentation_comment_token2);
-      if (lookahead == '*') ADVANCE(105);
-      if (lookahead == '/') ADVANCE(102);
-      END_STATE();
-    case 98:
-      ACCEPT_TOKEN(aux_sym_documentation_comment_token2);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(104);
+          lookahead != '\\') ADVANCE(42);
       END_STATE();
     case 99:
-      ACCEPT_TOKEN(aux_sym_documentation_comment_token3);
+      ACCEPT_TOKEN(aux_sym_documentation_comment_token2);
       END_STATE();
     case 100:
-      ACCEPT_TOKEN(anon_sym_STAR_SLASH);
+      ACCEPT_TOKEN(aux_sym_documentation_comment_token2);
+      if (lookahead == '#') ADVANCE(102);
+      if (lookahead == '/') ADVANCE(101);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(100);
+      if (lookahead != 0 &&
+          lookahead != '*') ADVANCE(99);
       END_STATE();
     case 101:
-      ACCEPT_TOKEN(sym_line_comment);
-      if (lookahead == '/') ADVANCE(91);
-      if (('-' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(103);
-      if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(104);
+      ACCEPT_TOKEN(aux_sym_documentation_comment_token2);
+      if (lookahead == '*') ADVANCE(109);
+      if (lookahead == '/') ADVANCE(106);
       END_STATE();
     case 102:
-      ACCEPT_TOKEN(sym_line_comment);
-      if (lookahead == '/') ADVANCE(92);
+      ACCEPT_TOKEN(aux_sym_documentation_comment_token2);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(104);
+          lookahead != '\n') ADVANCE(108);
       END_STATE();
     case 103:
+      ACCEPT_TOKEN(aux_sym_documentation_comment_token3);
+      END_STATE();
+    case 104:
+      ACCEPT_TOKEN(anon_sym_STAR_SLASH);
+      END_STATE();
+    case 105:
+      ACCEPT_TOKEN(sym_line_comment);
+      if (lookahead == '/') ADVANCE(95);
+      if (('-' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(107);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(108);
+      END_STATE();
+    case 106:
+      ACCEPT_TOKEN(sym_line_comment);
+      if (lookahead == '/') ADVANCE(96);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(108);
+      END_STATE();
+    case 107:
       ACCEPT_TOKEN(sym_line_comment);
       if (('-' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(103);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(107);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(104);
+          lookahead != '\n') ADVANCE(108);
       END_STATE();
-    case 104:
+    case 108:
       ACCEPT_TOKEN(sym_line_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(104);
+          lookahead != '\n') ADVANCE(108);
       END_STATE();
-    case 105:
+    case 109:
       ACCEPT_TOKEN(anon_sym_SLASH_STAR);
-      if (lookahead == '*') ADVANCE(93);
+      if (lookahead == '*') ADVANCE(97);
       END_STATE();
-    case 106:
+    case 110:
       ACCEPT_TOKEN(anon_sym_SLASH_STAR);
-      if (lookahead == '*') ADVANCE(94);
+      if (lookahead == '*') ADVANCE(98);
       if (lookahead != 0 &&
           lookahead != '"' &&
           lookahead != '$' &&
-          lookahead != '\\') ADVANCE(38);
+          lookahead != '\\') ADVANCE(42);
       END_STATE();
     default:
       return false;
@@ -1709,12 +1750,12 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
         'n', 10,
         'o', 11,
         'p', 12,
-        'r', 13,
-        's', 14,
-        't', 15,
-        'u', 16,
-        'v', 17,
-        'w', 18,
+        's', 13,
+        't', 14,
+        'u', 15,
+        'v', 16,
+        'w', 17,
+        'y', 18,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(0);
@@ -1750,424 +1791,444 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'f') ADVANCE(33);
       if (lookahead == 'm') ADVANCE(34);
       if (lookahead == 'n') ADVANCE(35);
+      if (lookahead == 's') ADVANCE(36);
       END_STATE();
     case 8:
-      if (lookahead == 'o') ADVANCE(36);
+      if (lookahead == 'o') ADVANCE(37);
       END_STATE();
     case 9:
-      if (lookahead == 'a') ADVANCE(37);
+      if (lookahead == 'a') ADVANCE(38);
       END_STATE();
     case 10:
-      if (lookahead == 'u') ADVANCE(38);
+      if (lookahead == 'u') ADVANCE(39);
       END_STATE();
     case 11:
-      if (lookahead == 'r') ADVANCE(39);
+      if (lookahead == 'r') ADVANCE(40);
       END_STATE();
     case 12:
-      if (lookahead == 'u') ADVANCE(40);
+      if (lookahead == 'u') ADVANCE(41);
       END_STATE();
     case 13:
-      if (lookahead == 'e') ADVANCE(41);
-      END_STATE();
-    case 14:
       if (lookahead == 't') ADVANCE(42);
       END_STATE();
-    case 15:
+    case 14:
       if (lookahead == 'r') ADVANCE(43);
       END_STATE();
-    case 16:
+    case 15:
       if (lookahead == 'n') ADVANCE(44);
       if (lookahead == 'p') ADVANCE(45);
       END_STATE();
-    case 17:
+    case 16:
       if (lookahead == 'a') ADVANCE(46);
       END_STATE();
-    case 18:
+    case 17:
       if (lookahead == 'h') ADVANCE(47);
       END_STATE();
+    case 18:
+      if (lookahead == 'i') ADVANCE(48);
+      END_STATE();
     case 19:
-      if (lookahead == 'y') ADVANCE(48);
+      if (lookahead == 'y') ADVANCE(49);
       END_STATE();
     case 20:
-      if (lookahead == 'a') ADVANCE(49);
+      if (lookahead == 'a') ADVANCE(50);
       END_STATE();
     case 21:
-      if (lookahead == 's') ADVANCE(50);
+      if (lookahead == 's') ADVANCE(51);
       END_STATE();
     case 22:
-      if (lookahead == 't') ADVANCE(51);
+      if (lookahead == 't') ADVANCE(52);
       END_STATE();
     case 23:
       ACCEPT_TOKEN(anon_sym_cd);
       END_STATE();
     case 24:
-      if (lookahead == 'n') ADVANCE(52);
+      if (lookahead == 'm') ADVANCE(53);
+      if (lookahead == 'n') ADVANCE(54);
       END_STATE();
     case 25:
-      if (lookahead == 'h') ADVANCE(53);
+      if (lookahead == 'h') ADVANCE(55);
       END_STATE();
     case 26:
-      if (lookahead == 's') ADVANCE(54);
+      if (lookahead == 's') ADVANCE(56);
       END_STATE();
     case 27:
-      if (lookahead == 'u') ADVANCE(55);
+      if (lookahead == 'u') ADVANCE(57);
       END_STATE();
     case 28:
-      if (lookahead == 'r') ADVANCE(56);
+      if (lookahead == 'r') ADVANCE(58);
       END_STATE();
     case 29:
-      if (lookahead == 'i') ADVANCE(57);
+      if (lookahead == 'i') ADVANCE(59);
       END_STATE();
     case 30:
-      if (lookahead == 'l') ADVANCE(58);
+      if (lookahead == 'l') ADVANCE(60);
       END_STATE();
     case 31:
       ACCEPT_TOKEN(anon_sym_fn);
       END_STATE();
     case 32:
-      if (lookahead == 'r') ADVANCE(59);
+      if (lookahead == 'r') ADVANCE(61);
       END_STATE();
     case 33:
       ACCEPT_TOKEN(anon_sym_if);
       END_STATE();
     case 34:
-      if (lookahead == 'p') ADVANCE(60);
+      if (lookahead == 'p') ADVANCE(62);
       END_STATE();
     case 35:
-      if (lookahead == 's') ADVANCE(61);
+      if (lookahead == 's') ADVANCE(63);
       END_STATE();
     case 36:
-      if (lookahead == 'w') ADVANCE(62);
+      ACCEPT_TOKEN(anon_sym_is);
       END_STATE();
     case 37:
-      if (lookahead == 't') ADVANCE(63);
+      if (lookahead == 'w') ADVANCE(64);
       END_STATE();
     case 38:
-      if (lookahead == 'l') ADVANCE(64);
+      if (lookahead == 't') ADVANCE(65);
       END_STATE();
     case 39:
-      if (lookahead == 'e') ADVANCE(65);
+      if (lookahead == 'l') ADVANCE(66);
       END_STATE();
     case 40:
-      if (lookahead == 'b') ADVANCE(66);
+      if (lookahead == 'e') ADVANCE(67);
       END_STATE();
     case 41:
-      if (lookahead == 't') ADVANCE(67);
+      if (lookahead == 'b') ADVANCE(68);
       END_STATE();
     case 42:
-      if (lookahead == 'r') ADVANCE(68);
+      if (lookahead == 'r') ADVANCE(69);
       END_STATE();
     case 43:
-      if (lookahead == 'u') ADVANCE(69);
-      if (lookahead == 'y') ADVANCE(70);
+      if (lookahead == 'u') ADVANCE(70);
+      if (lookahead == 'y') ADVANCE(71);
       END_STATE();
     case 44:
-      if (lookahead == 'i') ADVANCE(71);
+      if (lookahead == 'i') ADVANCE(72);
       END_STATE();
     case 45:
-      if (lookahead == 'p') ADVANCE(72);
+      if (lookahead == 'p') ADVANCE(73);
       END_STATE();
     case 46:
-      if (lookahead == 'r') ADVANCE(73);
+      if (lookahead == 'r') ADVANCE(74);
       END_STATE();
     case 47:
-      if (lookahead == 'i') ADVANCE(74);
+      if (lookahead == 'i') ADVANCE(75);
       END_STATE();
     case 48:
-      if (lookahead == 'n') ADVANCE(75);
+      if (lookahead == 'e') ADVANCE(76);
       END_STATE();
     case 49:
-      if (lookahead == 'i') ADVANCE(76);
+      if (lookahead == 'n') ADVANCE(77);
       END_STATE();
     case 50:
-      if (lookahead == 'h') ADVANCE(77);
+      if (lookahead == 'i') ADVANCE(78);
       END_STATE();
     case 51:
-      if (lookahead == 'c') ADVANCE(78);
+      if (lookahead == 'h') ADVANCE(79);
       END_STATE();
     case 52:
-      if (lookahead == 's') ADVANCE(79);
+      if (lookahead == 'c') ADVANCE(80);
       END_STATE();
     case 53:
-      if (lookahead == 'o') ADVANCE(80);
+      if (lookahead == 'p') ADVANCE(81);
       END_STATE();
     case 54:
-      if (lookahead == 'e') ADVANCE(81);
+      if (lookahead == 's') ADVANCE(82);
       END_STATE();
     case 55:
-      if (lookahead == 'm') ADVANCE(82);
-      END_STATE();
-    case 56:
       if (lookahead == 'o') ADVANCE(83);
       END_STATE();
+    case 56:
+      if (lookahead == 'e') ADVANCE(84);
+      END_STATE();
     case 57:
-      if (lookahead == 't') ADVANCE(84);
+      if (lookahead == 'm') ADVANCE(85);
       END_STATE();
     case 58:
-      if (lookahead == 's') ADVANCE(85);
-      END_STATE();
-    case 59:
-      ACCEPT_TOKEN(anon_sym_for);
-      END_STATE();
-    case 60:
       if (lookahead == 'o') ADVANCE(86);
       END_STATE();
+    case 59:
+      if (lookahead == 't') ADVANCE(87);
+      END_STATE();
+    case 60:
+      if (lookahead == 's') ADVANCE(88);
+      END_STATE();
     case 61:
-      if (lookahead == 'p') ADVANCE(87);
+      ACCEPT_TOKEN(anon_sym_for);
       END_STATE();
     case 62:
-      if (lookahead == 'e') ADVANCE(88);
+      if (lookahead == 'o') ADVANCE(89);
       END_STATE();
     case 63:
-      if (lookahead == 'c') ADVANCE(89);
+      if (lookahead == 'p') ADVANCE(90);
       END_STATE();
     case 64:
-      if (lookahead == 'l') ADVANCE(90);
+      if (lookahead == 'e') ADVANCE(91);
       END_STATE();
     case 65:
-      if (lookahead == 'l') ADVANCE(91);
+      if (lookahead == 'c') ADVANCE(92);
       END_STATE();
     case 66:
-      ACCEPT_TOKEN(anon_sym_pub);
+      if (lookahead == 'l') ADVANCE(93);
       END_STATE();
     case 67:
-      if (lookahead == 'u') ADVANCE(92);
+      if (lookahead == 'l') ADVANCE(94);
       END_STATE();
     case 68:
-      if (lookahead == 'u') ADVANCE(93);
+      ACCEPT_TOKEN(anon_sym_pub);
       END_STATE();
     case 69:
-      if (lookahead == 'e') ADVANCE(94);
+      if (lookahead == 'u') ADVANCE(95);
       END_STATE();
     case 70:
-      ACCEPT_TOKEN(anon_sym_try);
-      END_STATE();
-    case 71:
-      if (lookahead == 'o') ADVANCE(95);
-      END_STATE();
-    case 72:
       if (lookahead == 'e') ADVANCE(96);
       END_STATE();
+    case 71:
+      ACCEPT_TOKEN(anon_sym_try);
+      END_STATE();
+    case 72:
+      if (lookahead == 'o') ADVANCE(97);
+      END_STATE();
     case 73:
-      ACCEPT_TOKEN(anon_sym_var);
+      if (lookahead == 'e') ADVANCE(98);
       END_STATE();
     case 74:
-      if (lookahead == 'l') ADVANCE(97);
+      ACCEPT_TOKEN(anon_sym_var);
       END_STATE();
     case 75:
-      if (lookahead == 'c') ADVANCE(98);
+      if (lookahead == 'l') ADVANCE(99);
       END_STATE();
     case 76:
-      if (lookahead == 't') ADVANCE(99);
+      if (lookahead == 'l') ADVANCE(100);
       END_STATE();
     case 77:
-      ACCEPT_TOKEN(sym_keyword_interop);
+      if (lookahead == 'c') ADVANCE(101);
       END_STATE();
     case 78:
-      if (lookahead == 'h') ADVANCE(100);
+      if (lookahead == 't') ADVANCE(102);
       END_STATE();
     case 79:
-      if (lookahead == 't') ADVANCE(101);
+      ACCEPT_TOKEN(sym_keyword_interop);
       END_STATE();
     case 80:
-      ACCEPT_TOKEN(anon_sym_echo);
+      if (lookahead == 'h') ADVANCE(103);
       END_STATE();
     case 81:
-      ACCEPT_TOKEN(anon_sym_else);
+      if (lookahead == 't') ADVANCE(104);
       END_STATE();
     case 82:
-      ACCEPT_TOKEN(anon_sym_enum);
+      if (lookahead == 't') ADVANCE(105);
       END_STATE();
     case 83:
-      if (lookahead == 'r') ADVANCE(102);
+      ACCEPT_TOKEN(anon_sym_echo);
       END_STATE();
     case 84:
-      ACCEPT_TOKEN(anon_sym_exit);
+      ACCEPT_TOKEN(anon_sym_else);
       END_STATE();
     case 85:
-      if (lookahead == 'e') ADVANCE(103);
+      ACCEPT_TOKEN(anon_sym_enum);
       END_STATE();
     case 86:
-      if (lookahead == 'r') ADVANCE(104);
-      END_STATE();
-    case 87:
-      if (lookahead == 'e') ADVANCE(105);
-      END_STATE();
-    case 88:
       if (lookahead == 'r') ADVANCE(106);
       END_STATE();
+    case 87:
+      ACCEPT_TOKEN(anon_sym_exit);
+      END_STATE();
+    case 88:
+      if (lookahead == 'e') ADVANCE(107);
+      END_STATE();
     case 89:
-      if (lookahead == 'h') ADVANCE(107);
+      if (lookahead == 'r') ADVANCE(108);
       END_STATE();
     case 90:
-      ACCEPT_TOKEN(sym_null_literal);
+      if (lookahead == 'e') ADVANCE(109);
       END_STATE();
     case 91:
-      if (lookahead == 's') ADVANCE(108);
+      if (lookahead == 'r') ADVANCE(110);
       END_STATE();
     case 92:
-      if (lookahead == 'r') ADVANCE(109);
+      if (lookahead == 'h') ADVANCE(111);
       END_STATE();
     case 93:
-      if (lookahead == 'c') ADVANCE(110);
+      ACCEPT_TOKEN(sym_null_literal);
       END_STATE();
     case 94:
-      ACCEPT_TOKEN(anon_sym_true);
+      if (lookahead == 's') ADVANCE(112);
       END_STATE();
     case 95:
-      if (lookahead == 'n') ADVANCE(111);
+      if (lookahead == 'c') ADVANCE(113);
       END_STATE();
     case 96:
-      if (lookahead == 'r') ADVANCE(112);
+      ACCEPT_TOKEN(anon_sym_true);
       END_STATE();
     case 97:
-      if (lookahead == 'e') ADVANCE(113);
+      if (lookahead == 'n') ADVANCE(114);
       END_STATE();
     case 98:
-      ACCEPT_TOKEN(anon_sym_async);
+      if (lookahead == 'r') ADVANCE(115);
       END_STATE();
     case 99:
-      ACCEPT_TOKEN(anon_sym_await);
-      END_STATE();
-    case 100:
-      ACCEPT_TOKEN(anon_sym_catch);
-      END_STATE();
-    case 101:
-      ACCEPT_TOKEN(anon_sym_const);
-      END_STATE();
-    case 102:
-      ACCEPT_TOKEN(anon_sym_error);
-      END_STATE();
-    case 103:
-      ACCEPT_TOKEN(anon_sym_false);
-      END_STATE();
-    case 104:
-      if (lookahead == 't') ADVANCE(114);
-      END_STATE();
-    case 105:
-      if (lookahead == 'c') ADVANCE(115);
-      END_STATE();
-    case 106:
-      ACCEPT_TOKEN(anon_sym_lower);
-      END_STATE();
-    case 107:
-      ACCEPT_TOKEN(anon_sym_match);
-      END_STATE();
-    case 108:
       if (lookahead == 'e') ADVANCE(116);
       END_STATE();
-    case 109:
-      if (lookahead == 'n') ADVANCE(117);
+    case 100:
+      if (lookahead == 'd') ADVANCE(117);
       END_STATE();
-    case 110:
-      if (lookahead == 't') ADVANCE(118);
+    case 101:
+      ACCEPT_TOKEN(anon_sym_async);
       END_STATE();
-    case 111:
-      ACCEPT_TOKEN(anon_sym_union);
+    case 102:
+      ACCEPT_TOKEN(anon_sym_await);
       END_STATE();
-    case 112:
-      ACCEPT_TOKEN(anon_sym_upper);
+    case 103:
+      ACCEPT_TOKEN(anon_sym_catch);
       END_STATE();
-    case 113:
-      ACCEPT_TOKEN(anon_sym_while);
+    case 104:
+      if (lookahead == 'i') ADVANCE(118);
       END_STATE();
-    case 114:
-      ACCEPT_TOKEN(sym_keyword_import);
+    case 105:
+      ACCEPT_TOKEN(anon_sym_const);
       END_STATE();
-    case 115:
+    case 106:
+      ACCEPT_TOKEN(anon_sym_error);
+      END_STATE();
+    case 107:
+      ACCEPT_TOKEN(anon_sym_false);
+      END_STATE();
+    case 108:
       if (lookahead == 't') ADVANCE(119);
       END_STATE();
+    case 109:
+      if (lookahead == 'c') ADVANCE(120);
+      END_STATE();
+    case 110:
+      ACCEPT_TOKEN(anon_sym_lower);
+      END_STATE();
+    case 111:
+      ACCEPT_TOKEN(anon_sym_match);
+      END_STATE();
+    case 112:
+      if (lookahead == 'e') ADVANCE(121);
+      END_STATE();
+    case 113:
+      if (lookahead == 't') ADVANCE(122);
+      END_STATE();
+    case 114:
+      ACCEPT_TOKEN(anon_sym_union);
+      END_STATE();
+    case 115:
+      ACCEPT_TOKEN(anon_sym_upper);
+      END_STATE();
     case 116:
-      ACCEPT_TOKEN(anon_sym_orelse);
+      ACCEPT_TOKEN(anon_sym_while);
       END_STATE();
     case 117:
-      ACCEPT_TOKEN(anon_sym_return);
+      ACCEPT_TOKEN(anon_sym_yield);
       END_STATE();
     case 118:
-      ACCEPT_TOKEN(anon_sym_struct);
+      if (lookahead == 'm') ADVANCE(123);
       END_STATE();
     case 119:
+      ACCEPT_TOKEN(sym_keyword_import);
+      END_STATE();
+    case 120:
+      if (lookahead == 't') ADVANCE(124);
+      END_STATE();
+    case 121:
+      ACCEPT_TOKEN(anon_sym_orelse);
+      END_STATE();
+    case 122:
+      ACCEPT_TOKEN(anon_sym_struct);
+      END_STATE();
+    case 123:
+      if (lookahead == 'e') ADVANCE(125);
+      END_STATE();
+    case 124:
       ACCEPT_TOKEN(anon_sym_inspect);
+      END_STATE();
+    case 125:
+      ACCEPT_TOKEN(anon_sym_comptime);
       END_STATE();
     default:
       return false;
   }
 }
 
-static const TSLexMode ts_lex_modes[STATE_COUNT] = {
+static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
-  [1] = {.lex_state = 23},
-  [2] = {.lex_state = 23},
-  [3] = {.lex_state = 23},
+  [1] = {.lex_state = 25},
+  [2] = {.lex_state = 25},
+  [3] = {.lex_state = 25},
   [4] = {.lex_state = 1},
-  [5] = {.lex_state = 23},
+  [5] = {.lex_state = 25},
   [6] = {.lex_state = 1},
-  [7] = {.lex_state = 23},
-  [8] = {.lex_state = 23},
+  [7] = {.lex_state = 25},
+  [8] = {.lex_state = 25},
   [9] = {.lex_state = 1},
   [10] = {.lex_state = 1},
   [11] = {.lex_state = 1},
   [12] = {.lex_state = 1},
-  [13] = {.lex_state = 23},
+  [13] = {.lex_state = 25},
   [14] = {.lex_state = 1},
   [15] = {.lex_state = 1},
   [16] = {.lex_state = 1},
   [17] = {.lex_state = 1},
   [18] = {.lex_state = 1},
-  [19] = {.lex_state = 23},
-  [20] = {.lex_state = 23},
-  [21] = {.lex_state = 23},
-  [22] = {.lex_state = 23},
-  [23] = {.lex_state = 23},
-  [24] = {.lex_state = 23},
-  [25] = {.lex_state = 23},
-  [26] = {.lex_state = 23},
-  [27] = {.lex_state = 23},
-  [28] = {.lex_state = 23},
-  [29] = {.lex_state = 23},
-  [30] = {.lex_state = 23},
-  [31] = {.lex_state = 23},
-  [32] = {.lex_state = 23},
-  [33] = {.lex_state = 23},
-  [34] = {.lex_state = 23},
-  [35] = {.lex_state = 23},
-  [36] = {.lex_state = 23},
-  [37] = {.lex_state = 23},
-  [38] = {.lex_state = 23},
-  [39] = {.lex_state = 23},
+  [19] = {.lex_state = 25},
+  [20] = {.lex_state = 25},
+  [21] = {.lex_state = 25},
+  [22] = {.lex_state = 25},
+  [23] = {.lex_state = 25},
+  [24] = {.lex_state = 25},
+  [25] = {.lex_state = 25},
+  [26] = {.lex_state = 25},
+  [27] = {.lex_state = 25},
+  [28] = {.lex_state = 25},
+  [29] = {.lex_state = 25},
+  [30] = {.lex_state = 25},
+  [31] = {.lex_state = 25},
+  [32] = {.lex_state = 25},
+  [33] = {.lex_state = 25},
+  [34] = {.lex_state = 25},
+  [35] = {.lex_state = 25},
+  [36] = {.lex_state = 25},
+  [37] = {.lex_state = 25},
+  [38] = {.lex_state = 25},
+  [39] = {.lex_state = 25},
   [40] = {.lex_state = 1},
-  [41] = {.lex_state = 23},
-  [42] = {.lex_state = 23},
-  [43] = {.lex_state = 23},
-  [44] = {.lex_state = 23},
-  [45] = {.lex_state = 23},
-  [46] = {.lex_state = 23},
-  [47] = {.lex_state = 23},
-  [48] = {.lex_state = 23},
-  [49] = {.lex_state = 23},
-  [50] = {.lex_state = 23},
-  [51] = {.lex_state = 23},
-  [52] = {.lex_state = 23},
-  [53] = {.lex_state = 23},
-  [54] = {.lex_state = 23},
-  [55] = {.lex_state = 23},
-  [56] = {.lex_state = 23},
-  [57] = {.lex_state = 23},
-  [58] = {.lex_state = 23},
-  [59] = {.lex_state = 23},
-  [60] = {.lex_state = 23},
-  [61] = {.lex_state = 23},
-  [62] = {.lex_state = 23},
-  [63] = {.lex_state = 23},
-  [64] = {.lex_state = 23},
-  [65] = {.lex_state = 23},
-  [66] = {.lex_state = 23},
-  [67] = {.lex_state = 23},
-  [68] = {.lex_state = 23},
-  [69] = {.lex_state = 23},
-  [70] = {.lex_state = 23},
-  [71] = {.lex_state = 23},
-  [72] = {.lex_state = 23},
+  [41] = {.lex_state = 25},
+  [42] = {.lex_state = 25},
+  [43] = {.lex_state = 25},
+  [44] = {.lex_state = 25},
+  [45] = {.lex_state = 25},
+  [46] = {.lex_state = 25},
+  [47] = {.lex_state = 25},
+  [48] = {.lex_state = 25},
+  [49] = {.lex_state = 25},
+  [50] = {.lex_state = 25},
+  [51] = {.lex_state = 25},
+  [52] = {.lex_state = 25},
+  [53] = {.lex_state = 25},
+  [54] = {.lex_state = 25},
+  [55] = {.lex_state = 25},
+  [56] = {.lex_state = 25},
+  [57] = {.lex_state = 25},
+  [58] = {.lex_state = 25},
+  [59] = {.lex_state = 25},
+  [60] = {.lex_state = 25},
+  [61] = {.lex_state = 25},
+  [62] = {.lex_state = 25},
+  [63] = {.lex_state = 25},
+  [64] = {.lex_state = 25},
+  [65] = {.lex_state = 25},
+  [66] = {.lex_state = 25},
+  [67] = {.lex_state = 25},
+  [68] = {.lex_state = 25},
+  [69] = {.lex_state = 25},
+  [70] = {.lex_state = 25},
+  [71] = {.lex_state = 25},
+  [72] = {.lex_state = 25},
   [73] = {.lex_state = 1},
   [74] = {.lex_state = 1},
   [75] = {.lex_state = 1},
@@ -2245,6 +2306,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(1),
     [anon_sym_fn] = ACTIONS(1),
     [anon_sym_pub] = ACTIONS(1),
+    [anon_sym_comptime] = ACTIONS(1),
     [anon_sym_error] = ACTIONS(1),
     [anon_sym_enum] = ACTIONS(1),
     [anon_sym_union] = ACTIONS(1),
@@ -2254,8 +2316,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(1),
     [anon_sym_else] = ACTIONS(1),
     [anon_sym_match] = ACTIONS(1),
-    [anon_sym_return] = ACTIONS(1),
     [anon_sym_exit] = ACTIONS(1),
+    [anon_sym_yield] = ACTIONS(1),
+    [anon_sym_is] = ACTIONS(1),
     [anon_sym_for] = ACTIONS(1),
     [anon_sym_while] = ACTIONS(1),
     [sym_keyword_import] = ACTIONS(1),
@@ -2341,6 +2404,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(15),
     [anon_sym_fn] = ACTIONS(15),
     [anon_sym_pub] = ACTIONS(15),
+    [anon_sym_comptime] = ACTIONS(15),
     [anon_sym_error] = ACTIONS(17),
     [anon_sym_enum] = ACTIONS(17),
     [anon_sym_union] = ACTIONS(17),
@@ -2350,8 +2414,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(21),
     [anon_sym_else] = ACTIONS(21),
     [anon_sym_match] = ACTIONS(21),
-    [anon_sym_return] = ACTIONS(21),
     [anon_sym_exit] = ACTIONS(21),
+    [anon_sym_yield] = ACTIONS(21),
+    [anon_sym_is] = ACTIONS(21),
     [anon_sym_for] = ACTIONS(23),
     [anon_sym_while] = ACTIONS(23),
     [sym_keyword_import] = ACTIONS(13),
@@ -2432,6 +2497,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(15),
     [anon_sym_fn] = ACTIONS(15),
     [anon_sym_pub] = ACTIONS(15),
+    [anon_sym_comptime] = ACTIONS(15),
     [anon_sym_error] = ACTIONS(17),
     [anon_sym_enum] = ACTIONS(17),
     [anon_sym_union] = ACTIONS(17),
@@ -2441,8 +2507,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(21),
     [anon_sym_else] = ACTIONS(21),
     [anon_sym_match] = ACTIONS(21),
-    [anon_sym_return] = ACTIONS(21),
     [anon_sym_exit] = ACTIONS(21),
+    [anon_sym_yield] = ACTIONS(21),
+    [anon_sym_is] = ACTIONS(21),
     [anon_sym_for] = ACTIONS(23),
     [anon_sym_while] = ACTIONS(23),
     [sym_keyword_import] = ACTIONS(13),
@@ -2523,6 +2590,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(66),
     [anon_sym_fn] = ACTIONS(66),
     [anon_sym_pub] = ACTIONS(66),
+    [anon_sym_comptime] = ACTIONS(66),
     [anon_sym_error] = ACTIONS(69),
     [anon_sym_enum] = ACTIONS(69),
     [anon_sym_union] = ACTIONS(69),
@@ -2532,8 +2600,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(75),
     [anon_sym_else] = ACTIONS(75),
     [anon_sym_match] = ACTIONS(75),
-    [anon_sym_return] = ACTIONS(75),
     [anon_sym_exit] = ACTIONS(75),
+    [anon_sym_yield] = ACTIONS(75),
+    [anon_sym_is] = ACTIONS(75),
     [anon_sym_for] = ACTIONS(78),
     [anon_sym_while] = ACTIONS(78),
     [sym_keyword_import] = ACTIONS(63),
@@ -2615,6 +2684,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(134),
     [anon_sym_fn] = ACTIONS(134),
     [anon_sym_pub] = ACTIONS(134),
+    [anon_sym_comptime] = ACTIONS(134),
     [anon_sym_error] = ACTIONS(136),
     [anon_sym_enum] = ACTIONS(136),
     [anon_sym_union] = ACTIONS(136),
@@ -2624,8 +2694,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(140),
     [anon_sym_else] = ACTIONS(140),
     [anon_sym_match] = ACTIONS(140),
-    [anon_sym_return] = ACTIONS(140),
     [anon_sym_exit] = ACTIONS(140),
+    [anon_sym_yield] = ACTIONS(140),
+    [anon_sym_is] = ACTIONS(140),
     [anon_sym_for] = ACTIONS(142),
     [anon_sym_while] = ACTIONS(142),
     [sym_keyword_import] = ACTIONS(132),
@@ -2699,6 +2770,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(188),
     [anon_sym_fn] = ACTIONS(188),
     [anon_sym_pub] = ACTIONS(188),
+    [anon_sym_comptime] = ACTIONS(188),
     [anon_sym_error] = ACTIONS(188),
     [anon_sym_enum] = ACTIONS(188),
     [anon_sym_union] = ACTIONS(188),
@@ -2708,8 +2780,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(188),
     [anon_sym_else] = ACTIONS(188),
     [anon_sym_match] = ACTIONS(188),
-    [anon_sym_return] = ACTIONS(188),
     [anon_sym_exit] = ACTIONS(188),
+    [anon_sym_yield] = ACTIONS(188),
+    [anon_sym_is] = ACTIONS(188),
     [anon_sym_for] = ACTIONS(188),
     [anon_sym_while] = ACTIONS(188),
     [sym_keyword_import] = ACTIONS(188),
@@ -2791,6 +2864,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(193),
     [anon_sym_fn] = ACTIONS(193),
     [anon_sym_pub] = ACTIONS(193),
+    [anon_sym_comptime] = ACTIONS(193),
     [anon_sym_error] = ACTIONS(196),
     [anon_sym_enum] = ACTIONS(196),
     [anon_sym_union] = ACTIONS(196),
@@ -2800,8 +2874,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(202),
     [anon_sym_else] = ACTIONS(202),
     [anon_sym_match] = ACTIONS(202),
-    [anon_sym_return] = ACTIONS(202),
     [anon_sym_exit] = ACTIONS(202),
+    [anon_sym_yield] = ACTIONS(202),
+    [anon_sym_is] = ACTIONS(202),
     [anon_sym_for] = ACTIONS(205),
     [anon_sym_while] = ACTIONS(205),
     [sym_keyword_import] = ACTIONS(190),
@@ -2875,6 +2950,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(188),
     [anon_sym_fn] = ACTIONS(188),
     [anon_sym_pub] = ACTIONS(188),
+    [anon_sym_comptime] = ACTIONS(188),
     [anon_sym_error] = ACTIONS(188),
     [anon_sym_enum] = ACTIONS(188),
     [anon_sym_union] = ACTIONS(188),
@@ -2884,8 +2960,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(188),
     [anon_sym_else] = ACTIONS(188),
     [anon_sym_match] = ACTIONS(188),
-    [anon_sym_return] = ACTIONS(188),
     [anon_sym_exit] = ACTIONS(188),
+    [anon_sym_yield] = ACTIONS(188),
+    [anon_sym_is] = ACTIONS(188),
     [anon_sym_for] = ACTIONS(188),
     [anon_sym_while] = ACTIONS(188),
     [sym_keyword_import] = ACTIONS(188),
@@ -2963,6 +3040,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(272),
     [anon_sym_fn] = ACTIONS(272),
     [anon_sym_pub] = ACTIONS(272),
+    [anon_sym_comptime] = ACTIONS(272),
     [anon_sym_error] = ACTIONS(272),
     [anon_sym_enum] = ACTIONS(272),
     [anon_sym_union] = ACTIONS(272),
@@ -2972,8 +3050,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(272),
     [anon_sym_else] = ACTIONS(272),
     [anon_sym_match] = ACTIONS(272),
-    [anon_sym_return] = ACTIONS(272),
     [anon_sym_exit] = ACTIONS(272),
+    [anon_sym_yield] = ACTIONS(272),
+    [anon_sym_is] = ACTIONS(272),
     [anon_sym_for] = ACTIONS(272),
     [anon_sym_while] = ACTIONS(272),
     [sym_keyword_import] = ACTIONS(272),
@@ -3055,6 +3134,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(134),
     [anon_sym_fn] = ACTIONS(134),
     [anon_sym_pub] = ACTIONS(134),
+    [anon_sym_comptime] = ACTIONS(134),
     [anon_sym_error] = ACTIONS(136),
     [anon_sym_enum] = ACTIONS(136),
     [anon_sym_union] = ACTIONS(136),
@@ -3064,8 +3144,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(140),
     [anon_sym_else] = ACTIONS(140),
     [anon_sym_match] = ACTIONS(140),
-    [anon_sym_return] = ACTIONS(140),
     [anon_sym_exit] = ACTIONS(140),
+    [anon_sym_yield] = ACTIONS(140),
+    [anon_sym_is] = ACTIONS(140),
     [anon_sym_for] = ACTIONS(142),
     [anon_sym_while] = ACTIONS(142),
     [sym_keyword_import] = ACTIONS(132),
@@ -3143,6 +3224,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(134),
     [anon_sym_fn] = ACTIONS(134),
     [anon_sym_pub] = ACTIONS(134),
+    [anon_sym_comptime] = ACTIONS(134),
     [anon_sym_error] = ACTIONS(136),
     [anon_sym_enum] = ACTIONS(136),
     [anon_sym_union] = ACTIONS(136),
@@ -3152,8 +3234,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(140),
     [anon_sym_else] = ACTIONS(140),
     [anon_sym_match] = ACTIONS(140),
-    [anon_sym_return] = ACTIONS(140),
     [anon_sym_exit] = ACTIONS(140),
+    [anon_sym_yield] = ACTIONS(140),
+    [anon_sym_is] = ACTIONS(140),
     [anon_sym_for] = ACTIONS(142),
     [anon_sym_while] = ACTIONS(142),
     [sym_keyword_import] = ACTIONS(132),
@@ -3231,6 +3314,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(134),
     [anon_sym_fn] = ACTIONS(134),
     [anon_sym_pub] = ACTIONS(134),
+    [anon_sym_comptime] = ACTIONS(134),
     [anon_sym_error] = ACTIONS(136),
     [anon_sym_enum] = ACTIONS(136),
     [anon_sym_union] = ACTIONS(136),
@@ -3240,8 +3324,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(140),
     [anon_sym_else] = ACTIONS(140),
     [anon_sym_match] = ACTIONS(140),
-    [anon_sym_return] = ACTIONS(140),
     [anon_sym_exit] = ACTIONS(140),
+    [anon_sym_yield] = ACTIONS(140),
+    [anon_sym_is] = ACTIONS(140),
     [anon_sym_for] = ACTIONS(142),
     [anon_sym_while] = ACTIONS(142),
     [sym_keyword_import] = ACTIONS(132),
@@ -3319,6 +3404,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(134),
     [anon_sym_fn] = ACTIONS(134),
     [anon_sym_pub] = ACTIONS(134),
+    [anon_sym_comptime] = ACTIONS(134),
     [anon_sym_error] = ACTIONS(136),
     [anon_sym_enum] = ACTIONS(136),
     [anon_sym_union] = ACTIONS(136),
@@ -3328,8 +3414,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(140),
     [anon_sym_else] = ACTIONS(140),
     [anon_sym_match] = ACTIONS(140),
-    [anon_sym_return] = ACTIONS(140),
     [anon_sym_exit] = ACTIONS(140),
+    [anon_sym_yield] = ACTIONS(140),
+    [anon_sym_is] = ACTIONS(140),
     [anon_sym_for] = ACTIONS(142),
     [anon_sym_while] = ACTIONS(142),
     [sym_keyword_import] = ACTIONS(132),
@@ -3403,6 +3490,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(291),
     [anon_sym_fn] = ACTIONS(291),
     [anon_sym_pub] = ACTIONS(291),
+    [anon_sym_comptime] = ACTIONS(291),
     [anon_sym_error] = ACTIONS(293),
     [anon_sym_enum] = ACTIONS(293),
     [anon_sym_union] = ACTIONS(293),
@@ -3412,8 +3500,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(299),
     [anon_sym_else] = ACTIONS(299),
     [anon_sym_match] = ACTIONS(299),
-    [anon_sym_return] = ACTIONS(299),
     [anon_sym_exit] = ACTIONS(299),
+    [anon_sym_yield] = ACTIONS(299),
+    [anon_sym_is] = ACTIONS(299),
     [anon_sym_for] = ACTIONS(302),
     [anon_sym_while] = ACTIONS(302),
     [sym_keyword_import] = ACTIONS(288),
@@ -3495,6 +3584,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(134),
     [anon_sym_fn] = ACTIONS(134),
     [anon_sym_pub] = ACTIONS(134),
+    [anon_sym_comptime] = ACTIONS(134),
     [anon_sym_error] = ACTIONS(136),
     [anon_sym_enum] = ACTIONS(136),
     [anon_sym_union] = ACTIONS(136),
@@ -3504,8 +3594,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(140),
     [anon_sym_else] = ACTIONS(140),
     [anon_sym_match] = ACTIONS(140),
-    [anon_sym_return] = ACTIONS(140),
     [anon_sym_exit] = ACTIONS(140),
+    [anon_sym_yield] = ACTIONS(140),
+    [anon_sym_is] = ACTIONS(140),
     [anon_sym_for] = ACTIONS(142),
     [anon_sym_while] = ACTIONS(142),
     [sym_keyword_import] = ACTIONS(132),
@@ -3583,6 +3674,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(134),
     [anon_sym_fn] = ACTIONS(134),
     [anon_sym_pub] = ACTIONS(134),
+    [anon_sym_comptime] = ACTIONS(134),
     [anon_sym_error] = ACTIONS(136),
     [anon_sym_enum] = ACTIONS(136),
     [anon_sym_union] = ACTIONS(136),
@@ -3592,8 +3684,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(140),
     [anon_sym_else] = ACTIONS(140),
     [anon_sym_match] = ACTIONS(140),
-    [anon_sym_return] = ACTIONS(140),
     [anon_sym_exit] = ACTIONS(140),
+    [anon_sym_yield] = ACTIONS(140),
+    [anon_sym_is] = ACTIONS(140),
     [anon_sym_for] = ACTIONS(142),
     [anon_sym_while] = ACTIONS(142),
     [sym_keyword_import] = ACTIONS(132),
@@ -3671,6 +3764,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(193),
     [anon_sym_fn] = ACTIONS(193),
     [anon_sym_pub] = ACTIONS(193),
+    [anon_sym_comptime] = ACTIONS(193),
     [anon_sym_error] = ACTIONS(196),
     [anon_sym_enum] = ACTIONS(196),
     [anon_sym_union] = ACTIONS(196),
@@ -3680,8 +3774,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(202),
     [anon_sym_else] = ACTIONS(202),
     [anon_sym_match] = ACTIONS(202),
-    [anon_sym_return] = ACTIONS(202),
     [anon_sym_exit] = ACTIONS(202),
+    [anon_sym_yield] = ACTIONS(202),
+    [anon_sym_is] = ACTIONS(202),
     [anon_sym_for] = ACTIONS(205),
     [anon_sym_while] = ACTIONS(205),
     [sym_keyword_import] = ACTIONS(190),
@@ -3759,6 +3854,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(134),
     [anon_sym_fn] = ACTIONS(134),
     [anon_sym_pub] = ACTIONS(134),
+    [anon_sym_comptime] = ACTIONS(134),
     [anon_sym_error] = ACTIONS(136),
     [anon_sym_enum] = ACTIONS(136),
     [anon_sym_union] = ACTIONS(136),
@@ -3768,8 +3864,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(140),
     [anon_sym_else] = ACTIONS(140),
     [anon_sym_match] = ACTIONS(140),
-    [anon_sym_return] = ACTIONS(140),
     [anon_sym_exit] = ACTIONS(140),
+    [anon_sym_yield] = ACTIONS(140),
+    [anon_sym_is] = ACTIONS(140),
     [anon_sym_for] = ACTIONS(142),
     [anon_sym_while] = ACTIONS(142),
     [sym_keyword_import] = ACTIONS(132),
@@ -3847,6 +3944,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(193),
     [anon_sym_fn] = ACTIONS(193),
     [anon_sym_pub] = ACTIONS(193),
+    [anon_sym_comptime] = ACTIONS(193),
     [anon_sym_error] = ACTIONS(196),
     [anon_sym_enum] = ACTIONS(196),
     [anon_sym_union] = ACTIONS(196),
@@ -3856,8 +3954,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(202),
     [anon_sym_else] = ACTIONS(202),
     [anon_sym_match] = ACTIONS(202),
-    [anon_sym_return] = ACTIONS(202),
     [anon_sym_exit] = ACTIONS(202),
+    [anon_sym_yield] = ACTIONS(202),
+    [anon_sym_is] = ACTIONS(202),
     [anon_sym_for] = ACTIONS(205),
     [anon_sym_while] = ACTIONS(205),
     [sym_keyword_import] = ACTIONS(190),
@@ -3930,6 +4029,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(188),
     [anon_sym_fn] = ACTIONS(188),
     [anon_sym_pub] = ACTIONS(188),
+    [anon_sym_comptime] = ACTIONS(188),
     [anon_sym_error] = ACTIONS(188),
     [anon_sym_enum] = ACTIONS(188),
     [anon_sym_union] = ACTIONS(188),
@@ -3939,8 +4039,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(188),
     [anon_sym_else] = ACTIONS(188),
     [anon_sym_match] = ACTIONS(188),
-    [anon_sym_return] = ACTIONS(188),
     [anon_sym_exit] = ACTIONS(188),
+    [anon_sym_yield] = ACTIONS(188),
+    [anon_sym_is] = ACTIONS(188),
     [anon_sym_for] = ACTIONS(188),
     [anon_sym_while] = ACTIONS(188),
     [sym_keyword_import] = ACTIONS(188),
@@ -4017,6 +4118,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(188),
     [anon_sym_fn] = ACTIONS(188),
     [anon_sym_pub] = ACTIONS(188),
+    [anon_sym_comptime] = ACTIONS(188),
     [anon_sym_error] = ACTIONS(188),
     [anon_sym_enum] = ACTIONS(188),
     [anon_sym_union] = ACTIONS(188),
@@ -4026,8 +4128,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(188),
     [anon_sym_else] = ACTIONS(188),
     [anon_sym_match] = ACTIONS(188),
-    [anon_sym_return] = ACTIONS(188),
     [anon_sym_exit] = ACTIONS(188),
+    [anon_sym_yield] = ACTIONS(188),
+    [anon_sym_is] = ACTIONS(188),
     [anon_sym_for] = ACTIONS(188),
     [anon_sym_while] = ACTIONS(188),
     [sym_keyword_import] = ACTIONS(188),
@@ -4104,6 +4207,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(272),
     [anon_sym_fn] = ACTIONS(272),
     [anon_sym_pub] = ACTIONS(272),
+    [anon_sym_comptime] = ACTIONS(272),
     [anon_sym_error] = ACTIONS(272),
     [anon_sym_enum] = ACTIONS(272),
     [anon_sym_union] = ACTIONS(272),
@@ -4113,8 +4217,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(272),
     [anon_sym_else] = ACTIONS(272),
     [anon_sym_match] = ACTIONS(272),
-    [anon_sym_return] = ACTIONS(272),
     [anon_sym_exit] = ACTIONS(272),
+    [anon_sym_yield] = ACTIONS(272),
+    [anon_sym_is] = ACTIONS(272),
     [anon_sym_for] = ACTIONS(272),
     [anon_sym_while] = ACTIONS(272),
     [sym_keyword_import] = ACTIONS(272),
@@ -4191,6 +4296,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(188),
     [anon_sym_fn] = ACTIONS(188),
     [anon_sym_pub] = ACTIONS(188),
+    [anon_sym_comptime] = ACTIONS(188),
     [anon_sym_error] = ACTIONS(188),
     [anon_sym_enum] = ACTIONS(188),
     [anon_sym_union] = ACTIONS(188),
@@ -4200,8 +4306,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(188),
     [anon_sym_else] = ACTIONS(188),
     [anon_sym_match] = ACTIONS(188),
-    [anon_sym_return] = ACTIONS(188),
     [anon_sym_exit] = ACTIONS(188),
+    [anon_sym_yield] = ACTIONS(188),
+    [anon_sym_is] = ACTIONS(188),
     [anon_sym_for] = ACTIONS(188),
     [anon_sym_while] = ACTIONS(188),
     [sym_keyword_import] = ACTIONS(188),
@@ -4278,6 +4385,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(291),
     [anon_sym_fn] = ACTIONS(291),
     [anon_sym_pub] = ACTIONS(291),
+    [anon_sym_comptime] = ACTIONS(291),
     [anon_sym_error] = ACTIONS(364),
     [anon_sym_enum] = ACTIONS(364),
     [anon_sym_union] = ACTIONS(364),
@@ -4287,8 +4395,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(370),
     [anon_sym_else] = ACTIONS(370),
     [anon_sym_match] = ACTIONS(370),
-    [anon_sym_return] = ACTIONS(370),
     [anon_sym_exit] = ACTIONS(370),
+    [anon_sym_yield] = ACTIONS(370),
+    [anon_sym_is] = ACTIONS(370),
     [anon_sym_for] = ACTIONS(373),
     [anon_sym_while] = ACTIONS(373),
     [sym_keyword_import] = ACTIONS(361),
@@ -4365,6 +4474,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(188),
     [anon_sym_fn] = ACTIONS(188),
     [anon_sym_pub] = ACTIONS(188),
+    [anon_sym_comptime] = ACTIONS(188),
     [anon_sym_error] = ACTIONS(188),
     [anon_sym_enum] = ACTIONS(188),
     [anon_sym_union] = ACTIONS(188),
@@ -4374,8 +4484,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(188),
     [anon_sym_else] = ACTIONS(188),
     [anon_sym_match] = ACTIONS(188),
-    [anon_sym_return] = ACTIONS(188),
     [anon_sym_exit] = ACTIONS(188),
+    [anon_sym_yield] = ACTIONS(188),
+    [anon_sym_is] = ACTIONS(188),
     [anon_sym_for] = ACTIONS(188),
     [anon_sym_while] = ACTIONS(188),
     [sym_keyword_import] = ACTIONS(188),
@@ -4452,6 +4563,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(188),
     [anon_sym_fn] = ACTIONS(188),
     [anon_sym_pub] = ACTIONS(188),
+    [anon_sym_comptime] = ACTIONS(188),
     [anon_sym_error] = ACTIONS(188),
     [anon_sym_enum] = ACTIONS(188),
     [anon_sym_union] = ACTIONS(188),
@@ -4461,8 +4573,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(188),
     [anon_sym_else] = ACTIONS(188),
     [anon_sym_match] = ACTIONS(188),
-    [anon_sym_return] = ACTIONS(188),
     [anon_sym_exit] = ACTIONS(188),
+    [anon_sym_yield] = ACTIONS(188),
+    [anon_sym_is] = ACTIONS(188),
     [anon_sym_for] = ACTIONS(188),
     [anon_sym_while] = ACTIONS(188),
     [sym_keyword_import] = ACTIONS(188),
@@ -4539,6 +4652,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(272),
     [anon_sym_fn] = ACTIONS(272),
     [anon_sym_pub] = ACTIONS(272),
+    [anon_sym_comptime] = ACTIONS(272),
     [anon_sym_error] = ACTIONS(272),
     [anon_sym_enum] = ACTIONS(272),
     [anon_sym_union] = ACTIONS(272),
@@ -4548,8 +4662,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(272),
     [anon_sym_else] = ACTIONS(272),
     [anon_sym_match] = ACTIONS(272),
-    [anon_sym_return] = ACTIONS(272),
     [anon_sym_exit] = ACTIONS(272),
+    [anon_sym_yield] = ACTIONS(272),
+    [anon_sym_is] = ACTIONS(272),
     [anon_sym_for] = ACTIONS(272),
     [anon_sym_while] = ACTIONS(272),
     [sym_keyword_import] = ACTIONS(272),
@@ -4626,6 +4741,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(188),
     [anon_sym_fn] = ACTIONS(188),
     [anon_sym_pub] = ACTIONS(188),
+    [anon_sym_comptime] = ACTIONS(188),
     [anon_sym_error] = ACTIONS(188),
     [anon_sym_enum] = ACTIONS(188),
     [anon_sym_union] = ACTIONS(188),
@@ -4635,8 +4751,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(188),
     [anon_sym_else] = ACTIONS(188),
     [anon_sym_match] = ACTIONS(188),
-    [anon_sym_return] = ACTIONS(188),
     [anon_sym_exit] = ACTIONS(188),
+    [anon_sym_yield] = ACTIONS(188),
+    [anon_sym_is] = ACTIONS(188),
     [anon_sym_for] = ACTIONS(188),
     [anon_sym_while] = ACTIONS(188),
     [sym_keyword_import] = ACTIONS(188),
@@ -4713,6 +4830,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(272),
     [anon_sym_fn] = ACTIONS(272),
     [anon_sym_pub] = ACTIONS(272),
+    [anon_sym_comptime] = ACTIONS(272),
     [anon_sym_error] = ACTIONS(272),
     [anon_sym_enum] = ACTIONS(272),
     [anon_sym_union] = ACTIONS(272),
@@ -4722,8 +4840,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(272),
     [anon_sym_else] = ACTIONS(272),
     [anon_sym_match] = ACTIONS(272),
-    [anon_sym_return] = ACTIONS(272),
     [anon_sym_exit] = ACTIONS(272),
+    [anon_sym_yield] = ACTIONS(272),
+    [anon_sym_is] = ACTIONS(272),
     [anon_sym_for] = ACTIONS(272),
     [anon_sym_while] = ACTIONS(272),
     [sym_keyword_import] = ACTIONS(272),
@@ -4786,6 +4905,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(423),
     [anon_sym_fn] = ACTIONS(423),
     [anon_sym_pub] = ACTIONS(423),
+    [anon_sym_comptime] = ACTIONS(423),
     [anon_sym_error] = ACTIONS(423),
     [anon_sym_enum] = ACTIONS(423),
     [anon_sym_union] = ACTIONS(423),
@@ -4795,8 +4915,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(423),
     [anon_sym_else] = ACTIONS(423),
     [anon_sym_match] = ACTIONS(423),
-    [anon_sym_return] = ACTIONS(423),
     [anon_sym_exit] = ACTIONS(423),
+    [anon_sym_yield] = ACTIONS(423),
+    [anon_sym_is] = ACTIONS(423),
     [anon_sym_for] = ACTIONS(423),
     [anon_sym_while] = ACTIONS(423),
     [sym_keyword_import] = ACTIONS(423),
@@ -4859,6 +4980,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(423),
     [anon_sym_fn] = ACTIONS(423),
     [anon_sym_pub] = ACTIONS(423),
+    [anon_sym_comptime] = ACTIONS(423),
     [anon_sym_error] = ACTIONS(423),
     [anon_sym_enum] = ACTIONS(423),
     [anon_sym_union] = ACTIONS(423),
@@ -4868,8 +4990,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(423),
     [anon_sym_else] = ACTIONS(423),
     [anon_sym_match] = ACTIONS(423),
-    [anon_sym_return] = ACTIONS(423),
     [anon_sym_exit] = ACTIONS(423),
+    [anon_sym_yield] = ACTIONS(423),
+    [anon_sym_is] = ACTIONS(423),
     [anon_sym_for] = ACTIONS(423),
     [anon_sym_while] = ACTIONS(423),
     [sym_keyword_import] = ACTIONS(423),
@@ -4931,6 +5054,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(429),
     [anon_sym_fn] = ACTIONS(429),
     [anon_sym_pub] = ACTIONS(429),
+    [anon_sym_comptime] = ACTIONS(429),
     [anon_sym_error] = ACTIONS(429),
     [anon_sym_enum] = ACTIONS(429),
     [anon_sym_union] = ACTIONS(429),
@@ -4940,8 +5064,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(429),
     [anon_sym_else] = ACTIONS(429),
     [anon_sym_match] = ACTIONS(429),
-    [anon_sym_return] = ACTIONS(429),
     [anon_sym_exit] = ACTIONS(429),
+    [anon_sym_yield] = ACTIONS(429),
+    [anon_sym_is] = ACTIONS(429),
     [anon_sym_for] = ACTIONS(429),
     [anon_sym_while] = ACTIONS(429),
     [sym_keyword_import] = ACTIONS(429),
@@ -5002,6 +5127,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(433),
     [anon_sym_fn] = ACTIONS(433),
     [anon_sym_pub] = ACTIONS(433),
+    [anon_sym_comptime] = ACTIONS(433),
     [anon_sym_error] = ACTIONS(433),
     [anon_sym_enum] = ACTIONS(433),
     [anon_sym_union] = ACTIONS(433),
@@ -5011,8 +5137,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(433),
     [anon_sym_else] = ACTIONS(433),
     [anon_sym_match] = ACTIONS(433),
-    [anon_sym_return] = ACTIONS(433),
     [anon_sym_exit] = ACTIONS(433),
+    [anon_sym_yield] = ACTIONS(433),
+    [anon_sym_is] = ACTIONS(433),
     [anon_sym_for] = ACTIONS(433),
     [anon_sym_while] = ACTIONS(433),
     [sym_keyword_import] = ACTIONS(433),
@@ -5073,6 +5200,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(437),
     [anon_sym_fn] = ACTIONS(437),
     [anon_sym_pub] = ACTIONS(437),
+    [anon_sym_comptime] = ACTIONS(437),
     [anon_sym_error] = ACTIONS(437),
     [anon_sym_enum] = ACTIONS(437),
     [anon_sym_union] = ACTIONS(437),
@@ -5082,8 +5210,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(437),
     [anon_sym_else] = ACTIONS(437),
     [anon_sym_match] = ACTIONS(437),
-    [anon_sym_return] = ACTIONS(437),
     [anon_sym_exit] = ACTIONS(437),
+    [anon_sym_yield] = ACTIONS(437),
+    [anon_sym_is] = ACTIONS(437),
     [anon_sym_for] = ACTIONS(437),
     [anon_sym_while] = ACTIONS(437),
     [sym_keyword_import] = ACTIONS(437),
@@ -5144,6 +5273,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(441),
     [anon_sym_fn] = ACTIONS(441),
     [anon_sym_pub] = ACTIONS(441),
+    [anon_sym_comptime] = ACTIONS(441),
     [anon_sym_error] = ACTIONS(441),
     [anon_sym_enum] = ACTIONS(441),
     [anon_sym_union] = ACTIONS(441),
@@ -5153,8 +5283,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(441),
     [anon_sym_else] = ACTIONS(441),
     [anon_sym_match] = ACTIONS(441),
-    [anon_sym_return] = ACTIONS(441),
     [anon_sym_exit] = ACTIONS(441),
+    [anon_sym_yield] = ACTIONS(441),
+    [anon_sym_is] = ACTIONS(441),
     [anon_sym_for] = ACTIONS(441),
     [anon_sym_while] = ACTIONS(441),
     [sym_keyword_import] = ACTIONS(441),
@@ -5215,6 +5346,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(445),
     [anon_sym_fn] = ACTIONS(445),
     [anon_sym_pub] = ACTIONS(445),
+    [anon_sym_comptime] = ACTIONS(445),
     [anon_sym_error] = ACTIONS(445),
     [anon_sym_enum] = ACTIONS(445),
     [anon_sym_union] = ACTIONS(445),
@@ -5224,8 +5356,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(445),
     [anon_sym_else] = ACTIONS(445),
     [anon_sym_match] = ACTIONS(445),
-    [anon_sym_return] = ACTIONS(445),
     [anon_sym_exit] = ACTIONS(445),
+    [anon_sym_yield] = ACTIONS(445),
+    [anon_sym_is] = ACTIONS(445),
     [anon_sym_for] = ACTIONS(445),
     [anon_sym_while] = ACTIONS(445),
     [sym_keyword_import] = ACTIONS(445),
@@ -5286,6 +5419,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(449),
     [anon_sym_fn] = ACTIONS(449),
     [anon_sym_pub] = ACTIONS(449),
+    [anon_sym_comptime] = ACTIONS(449),
     [anon_sym_error] = ACTIONS(449),
     [anon_sym_enum] = ACTIONS(449),
     [anon_sym_union] = ACTIONS(449),
@@ -5295,8 +5429,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(449),
     [anon_sym_else] = ACTIONS(449),
     [anon_sym_match] = ACTIONS(449),
-    [anon_sym_return] = ACTIONS(449),
     [anon_sym_exit] = ACTIONS(449),
+    [anon_sym_yield] = ACTIONS(449),
+    [anon_sym_is] = ACTIONS(449),
     [anon_sym_for] = ACTIONS(449),
     [anon_sym_while] = ACTIONS(449),
     [sym_keyword_import] = ACTIONS(449),
@@ -5357,6 +5492,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(453),
     [anon_sym_fn] = ACTIONS(453),
     [anon_sym_pub] = ACTIONS(453),
+    [anon_sym_comptime] = ACTIONS(453),
     [anon_sym_error] = ACTIONS(453),
     [anon_sym_enum] = ACTIONS(453),
     [anon_sym_union] = ACTIONS(453),
@@ -5366,8 +5502,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(453),
     [anon_sym_else] = ACTIONS(453),
     [anon_sym_match] = ACTIONS(453),
-    [anon_sym_return] = ACTIONS(453),
     [anon_sym_exit] = ACTIONS(453),
+    [anon_sym_yield] = ACTIONS(453),
+    [anon_sym_is] = ACTIONS(453),
     [anon_sym_for] = ACTIONS(453),
     [anon_sym_while] = ACTIONS(453),
     [sym_keyword_import] = ACTIONS(453),
@@ -5428,6 +5565,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(457),
     [anon_sym_fn] = ACTIONS(457),
     [anon_sym_pub] = ACTIONS(457),
+    [anon_sym_comptime] = ACTIONS(457),
     [anon_sym_error] = ACTIONS(457),
     [anon_sym_enum] = ACTIONS(457),
     [anon_sym_union] = ACTIONS(457),
@@ -5437,8 +5575,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(457),
     [anon_sym_else] = ACTIONS(457),
     [anon_sym_match] = ACTIONS(457),
-    [anon_sym_return] = ACTIONS(457),
     [anon_sym_exit] = ACTIONS(457),
+    [anon_sym_yield] = ACTIONS(457),
+    [anon_sym_is] = ACTIONS(457),
     [anon_sym_for] = ACTIONS(457),
     [anon_sym_while] = ACTIONS(457),
     [sym_keyword_import] = ACTIONS(457),
@@ -5499,6 +5638,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(461),
     [anon_sym_fn] = ACTIONS(461),
     [anon_sym_pub] = ACTIONS(461),
+    [anon_sym_comptime] = ACTIONS(461),
     [anon_sym_error] = ACTIONS(461),
     [anon_sym_enum] = ACTIONS(461),
     [anon_sym_union] = ACTIONS(461),
@@ -5508,8 +5648,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(461),
     [anon_sym_else] = ACTIONS(461),
     [anon_sym_match] = ACTIONS(461),
-    [anon_sym_return] = ACTIONS(461),
     [anon_sym_exit] = ACTIONS(461),
+    [anon_sym_yield] = ACTIONS(461),
+    [anon_sym_is] = ACTIONS(461),
     [anon_sym_for] = ACTIONS(461),
     [anon_sym_while] = ACTIONS(461),
     [sym_keyword_import] = ACTIONS(461),
@@ -5571,6 +5712,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(423),
     [anon_sym_fn] = ACTIONS(423),
     [anon_sym_pub] = ACTIONS(423),
+    [anon_sym_comptime] = ACTIONS(423),
     [anon_sym_error] = ACTIONS(423),
     [anon_sym_enum] = ACTIONS(423),
     [anon_sym_union] = ACTIONS(423),
@@ -5580,8 +5722,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(423),
     [anon_sym_else] = ACTIONS(423),
     [anon_sym_match] = ACTIONS(423),
-    [anon_sym_return] = ACTIONS(423),
     [anon_sym_exit] = ACTIONS(423),
+    [anon_sym_yield] = ACTIONS(423),
+    [anon_sym_is] = ACTIONS(423),
     [anon_sym_for] = ACTIONS(423),
     [anon_sym_while] = ACTIONS(423),
     [sym_keyword_import] = ACTIONS(423),
@@ -5641,6 +5784,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(465),
     [anon_sym_fn] = ACTIONS(465),
     [anon_sym_pub] = ACTIONS(465),
+    [anon_sym_comptime] = ACTIONS(465),
     [anon_sym_error] = ACTIONS(465),
     [anon_sym_enum] = ACTIONS(465),
     [anon_sym_union] = ACTIONS(465),
@@ -5650,8 +5794,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(465),
     [anon_sym_else] = ACTIONS(465),
     [anon_sym_match] = ACTIONS(465),
-    [anon_sym_return] = ACTIONS(465),
     [anon_sym_exit] = ACTIONS(465),
+    [anon_sym_yield] = ACTIONS(465),
+    [anon_sym_is] = ACTIONS(465),
     [anon_sym_for] = ACTIONS(465),
     [anon_sym_while] = ACTIONS(465),
     [sym_keyword_import] = ACTIONS(465),
@@ -5712,6 +5857,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(469),
     [anon_sym_fn] = ACTIONS(469),
     [anon_sym_pub] = ACTIONS(469),
+    [anon_sym_comptime] = ACTIONS(469),
     [anon_sym_error] = ACTIONS(469),
     [anon_sym_enum] = ACTIONS(469),
     [anon_sym_union] = ACTIONS(469),
@@ -5721,8 +5867,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(469),
     [anon_sym_else] = ACTIONS(469),
     [anon_sym_match] = ACTIONS(469),
-    [anon_sym_return] = ACTIONS(469),
     [anon_sym_exit] = ACTIONS(469),
+    [anon_sym_yield] = ACTIONS(469),
+    [anon_sym_is] = ACTIONS(469),
     [anon_sym_for] = ACTIONS(469),
     [anon_sym_while] = ACTIONS(469),
     [sym_keyword_import] = ACTIONS(469),
@@ -5783,6 +5930,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(473),
     [anon_sym_fn] = ACTIONS(473),
     [anon_sym_pub] = ACTIONS(473),
+    [anon_sym_comptime] = ACTIONS(473),
     [anon_sym_error] = ACTIONS(473),
     [anon_sym_enum] = ACTIONS(473),
     [anon_sym_union] = ACTIONS(473),
@@ -5792,8 +5940,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(473),
     [anon_sym_else] = ACTIONS(473),
     [anon_sym_match] = ACTIONS(473),
-    [anon_sym_return] = ACTIONS(473),
     [anon_sym_exit] = ACTIONS(473),
+    [anon_sym_yield] = ACTIONS(473),
+    [anon_sym_is] = ACTIONS(473),
     [anon_sym_for] = ACTIONS(473),
     [anon_sym_while] = ACTIONS(473),
     [sym_keyword_import] = ACTIONS(473),
@@ -5854,6 +6003,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(477),
     [anon_sym_fn] = ACTIONS(477),
     [anon_sym_pub] = ACTIONS(477),
+    [anon_sym_comptime] = ACTIONS(477),
     [anon_sym_error] = ACTIONS(477),
     [anon_sym_enum] = ACTIONS(477),
     [anon_sym_union] = ACTIONS(477),
@@ -5863,8 +6013,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(477),
     [anon_sym_else] = ACTIONS(477),
     [anon_sym_match] = ACTIONS(477),
-    [anon_sym_return] = ACTIONS(477),
     [anon_sym_exit] = ACTIONS(477),
+    [anon_sym_yield] = ACTIONS(477),
+    [anon_sym_is] = ACTIONS(477),
     [anon_sym_for] = ACTIONS(477),
     [anon_sym_while] = ACTIONS(477),
     [sym_keyword_import] = ACTIONS(477),
@@ -5925,6 +6076,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(481),
     [anon_sym_fn] = ACTIONS(481),
     [anon_sym_pub] = ACTIONS(481),
+    [anon_sym_comptime] = ACTIONS(481),
     [anon_sym_error] = ACTIONS(481),
     [anon_sym_enum] = ACTIONS(481),
     [anon_sym_union] = ACTIONS(481),
@@ -5934,8 +6086,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(481),
     [anon_sym_else] = ACTIONS(481),
     [anon_sym_match] = ACTIONS(481),
-    [anon_sym_return] = ACTIONS(481),
     [anon_sym_exit] = ACTIONS(481),
+    [anon_sym_yield] = ACTIONS(481),
+    [anon_sym_is] = ACTIONS(481),
     [anon_sym_for] = ACTIONS(481),
     [anon_sym_while] = ACTIONS(481),
     [sym_keyword_import] = ACTIONS(481),
@@ -5996,6 +6149,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(485),
     [anon_sym_fn] = ACTIONS(485),
     [anon_sym_pub] = ACTIONS(485),
+    [anon_sym_comptime] = ACTIONS(485),
     [anon_sym_error] = ACTIONS(485),
     [anon_sym_enum] = ACTIONS(485),
     [anon_sym_union] = ACTIONS(485),
@@ -6005,8 +6159,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(485),
     [anon_sym_else] = ACTIONS(485),
     [anon_sym_match] = ACTIONS(485),
-    [anon_sym_return] = ACTIONS(485),
     [anon_sym_exit] = ACTIONS(485),
+    [anon_sym_yield] = ACTIONS(485),
+    [anon_sym_is] = ACTIONS(485),
     [anon_sym_for] = ACTIONS(485),
     [anon_sym_while] = ACTIONS(485),
     [sym_keyword_import] = ACTIONS(485),
@@ -6067,6 +6222,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(489),
     [anon_sym_fn] = ACTIONS(489),
     [anon_sym_pub] = ACTIONS(489),
+    [anon_sym_comptime] = ACTIONS(489),
     [anon_sym_error] = ACTIONS(489),
     [anon_sym_enum] = ACTIONS(489),
     [anon_sym_union] = ACTIONS(489),
@@ -6076,8 +6232,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(489),
     [anon_sym_else] = ACTIONS(489),
     [anon_sym_match] = ACTIONS(489),
-    [anon_sym_return] = ACTIONS(489),
     [anon_sym_exit] = ACTIONS(489),
+    [anon_sym_yield] = ACTIONS(489),
+    [anon_sym_is] = ACTIONS(489),
     [anon_sym_for] = ACTIONS(489),
     [anon_sym_while] = ACTIONS(489),
     [sym_keyword_import] = ACTIONS(489),
@@ -6138,6 +6295,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(493),
     [anon_sym_fn] = ACTIONS(493),
     [anon_sym_pub] = ACTIONS(493),
+    [anon_sym_comptime] = ACTIONS(493),
     [anon_sym_error] = ACTIONS(493),
     [anon_sym_enum] = ACTIONS(493),
     [anon_sym_union] = ACTIONS(493),
@@ -6147,8 +6305,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(493),
     [anon_sym_else] = ACTIONS(493),
     [anon_sym_match] = ACTIONS(493),
-    [anon_sym_return] = ACTIONS(493),
     [anon_sym_exit] = ACTIONS(493),
+    [anon_sym_yield] = ACTIONS(493),
+    [anon_sym_is] = ACTIONS(493),
     [anon_sym_for] = ACTIONS(493),
     [anon_sym_while] = ACTIONS(493),
     [sym_keyword_import] = ACTIONS(493),
@@ -6209,6 +6368,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(497),
     [anon_sym_fn] = ACTIONS(497),
     [anon_sym_pub] = ACTIONS(497),
+    [anon_sym_comptime] = ACTIONS(497),
     [anon_sym_error] = ACTIONS(497),
     [anon_sym_enum] = ACTIONS(497),
     [anon_sym_union] = ACTIONS(497),
@@ -6218,8 +6378,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(497),
     [anon_sym_else] = ACTIONS(497),
     [anon_sym_match] = ACTIONS(497),
-    [anon_sym_return] = ACTIONS(497),
     [anon_sym_exit] = ACTIONS(497),
+    [anon_sym_yield] = ACTIONS(497),
+    [anon_sym_is] = ACTIONS(497),
     [anon_sym_for] = ACTIONS(497),
     [anon_sym_while] = ACTIONS(497),
     [sym_keyword_import] = ACTIONS(497),
@@ -6280,6 +6441,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(501),
     [anon_sym_fn] = ACTIONS(501),
     [anon_sym_pub] = ACTIONS(501),
+    [anon_sym_comptime] = ACTIONS(501),
     [anon_sym_error] = ACTIONS(501),
     [anon_sym_enum] = ACTIONS(501),
     [anon_sym_union] = ACTIONS(501),
@@ -6289,8 +6451,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(501),
     [anon_sym_else] = ACTIONS(501),
     [anon_sym_match] = ACTIONS(501),
-    [anon_sym_return] = ACTIONS(501),
     [anon_sym_exit] = ACTIONS(501),
+    [anon_sym_yield] = ACTIONS(501),
+    [anon_sym_is] = ACTIONS(501),
     [anon_sym_for] = ACTIONS(501),
     [anon_sym_while] = ACTIONS(501),
     [sym_keyword_import] = ACTIONS(501),
@@ -6351,6 +6514,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(423),
     [anon_sym_fn] = ACTIONS(423),
     [anon_sym_pub] = ACTIONS(423),
+    [anon_sym_comptime] = ACTIONS(423),
     [anon_sym_error] = ACTIONS(423),
     [anon_sym_enum] = ACTIONS(423),
     [anon_sym_union] = ACTIONS(423),
@@ -6360,8 +6524,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(423),
     [anon_sym_else] = ACTIONS(423),
     [anon_sym_match] = ACTIONS(423),
-    [anon_sym_return] = ACTIONS(423),
     [anon_sym_exit] = ACTIONS(423),
+    [anon_sym_yield] = ACTIONS(423),
+    [anon_sym_is] = ACTIONS(423),
     [anon_sym_for] = ACTIONS(423),
     [anon_sym_while] = ACTIONS(423),
     [sym_keyword_import] = ACTIONS(423),
@@ -6422,6 +6587,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(505),
     [anon_sym_fn] = ACTIONS(505),
     [anon_sym_pub] = ACTIONS(505),
+    [anon_sym_comptime] = ACTIONS(505),
     [anon_sym_error] = ACTIONS(505),
     [anon_sym_enum] = ACTIONS(505),
     [anon_sym_union] = ACTIONS(505),
@@ -6431,8 +6597,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(505),
     [anon_sym_else] = ACTIONS(505),
     [anon_sym_match] = ACTIONS(505),
-    [anon_sym_return] = ACTIONS(505),
     [anon_sym_exit] = ACTIONS(505),
+    [anon_sym_yield] = ACTIONS(505),
+    [anon_sym_is] = ACTIONS(505),
     [anon_sym_for] = ACTIONS(505),
     [anon_sym_while] = ACTIONS(505),
     [sym_keyword_import] = ACTIONS(505),
@@ -6493,6 +6660,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(509),
     [anon_sym_fn] = ACTIONS(509),
     [anon_sym_pub] = ACTIONS(509),
+    [anon_sym_comptime] = ACTIONS(509),
     [anon_sym_error] = ACTIONS(509),
     [anon_sym_enum] = ACTIONS(509),
     [anon_sym_union] = ACTIONS(509),
@@ -6502,8 +6670,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(509),
     [anon_sym_else] = ACTIONS(509),
     [anon_sym_match] = ACTIONS(509),
-    [anon_sym_return] = ACTIONS(509),
     [anon_sym_exit] = ACTIONS(509),
+    [anon_sym_yield] = ACTIONS(509),
+    [anon_sym_is] = ACTIONS(509),
     [anon_sym_for] = ACTIONS(509),
     [anon_sym_while] = ACTIONS(509),
     [sym_keyword_import] = ACTIONS(509),
@@ -6563,6 +6732,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(433),
     [anon_sym_fn] = ACTIONS(433),
     [anon_sym_pub] = ACTIONS(433),
+    [anon_sym_comptime] = ACTIONS(433),
     [anon_sym_error] = ACTIONS(433),
     [anon_sym_enum] = ACTIONS(433),
     [anon_sym_union] = ACTIONS(433),
@@ -6572,8 +6742,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(433),
     [anon_sym_else] = ACTIONS(433),
     [anon_sym_match] = ACTIONS(433),
-    [anon_sym_return] = ACTIONS(433),
     [anon_sym_exit] = ACTIONS(433),
+    [anon_sym_yield] = ACTIONS(433),
+    [anon_sym_is] = ACTIONS(433),
     [anon_sym_for] = ACTIONS(433),
     [anon_sym_while] = ACTIONS(433),
     [sym_keyword_import] = ACTIONS(433),
@@ -6633,6 +6804,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(481),
     [anon_sym_fn] = ACTIONS(481),
     [anon_sym_pub] = ACTIONS(481),
+    [anon_sym_comptime] = ACTIONS(481),
     [anon_sym_error] = ACTIONS(481),
     [anon_sym_enum] = ACTIONS(481),
     [anon_sym_union] = ACTIONS(481),
@@ -6642,8 +6814,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(481),
     [anon_sym_else] = ACTIONS(481),
     [anon_sym_match] = ACTIONS(481),
-    [anon_sym_return] = ACTIONS(481),
     [anon_sym_exit] = ACTIONS(481),
+    [anon_sym_yield] = ACTIONS(481),
+    [anon_sym_is] = ACTIONS(481),
     [anon_sym_for] = ACTIONS(481),
     [anon_sym_while] = ACTIONS(481),
     [sym_keyword_import] = ACTIONS(481),
@@ -6703,6 +6876,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(477),
     [anon_sym_fn] = ACTIONS(477),
     [anon_sym_pub] = ACTIONS(477),
+    [anon_sym_comptime] = ACTIONS(477),
     [anon_sym_error] = ACTIONS(477),
     [anon_sym_enum] = ACTIONS(477),
     [anon_sym_union] = ACTIONS(477),
@@ -6712,8 +6886,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(477),
     [anon_sym_else] = ACTIONS(477),
     [anon_sym_match] = ACTIONS(477),
-    [anon_sym_return] = ACTIONS(477),
     [anon_sym_exit] = ACTIONS(477),
+    [anon_sym_yield] = ACTIONS(477),
+    [anon_sym_is] = ACTIONS(477),
     [anon_sym_for] = ACTIONS(477),
     [anon_sym_while] = ACTIONS(477),
     [sym_keyword_import] = ACTIONS(477),
@@ -6773,6 +6948,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(493),
     [anon_sym_fn] = ACTIONS(493),
     [anon_sym_pub] = ACTIONS(493),
+    [anon_sym_comptime] = ACTIONS(493),
     [anon_sym_error] = ACTIONS(493),
     [anon_sym_enum] = ACTIONS(493),
     [anon_sym_union] = ACTIONS(493),
@@ -6782,8 +6958,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(493),
     [anon_sym_else] = ACTIONS(493),
     [anon_sym_match] = ACTIONS(493),
-    [anon_sym_return] = ACTIONS(493),
     [anon_sym_exit] = ACTIONS(493),
+    [anon_sym_yield] = ACTIONS(493),
+    [anon_sym_is] = ACTIONS(493),
     [anon_sym_for] = ACTIONS(493),
     [anon_sym_while] = ACTIONS(493),
     [sym_keyword_import] = ACTIONS(493),
@@ -6843,6 +7020,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(423),
     [anon_sym_fn] = ACTIONS(423),
     [anon_sym_pub] = ACTIONS(423),
+    [anon_sym_comptime] = ACTIONS(423),
     [anon_sym_error] = ACTIONS(423),
     [anon_sym_enum] = ACTIONS(423),
     [anon_sym_union] = ACTIONS(423),
@@ -6852,8 +7030,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(423),
     [anon_sym_else] = ACTIONS(423),
     [anon_sym_match] = ACTIONS(423),
-    [anon_sym_return] = ACTIONS(423),
     [anon_sym_exit] = ACTIONS(423),
+    [anon_sym_yield] = ACTIONS(423),
+    [anon_sym_is] = ACTIONS(423),
     [anon_sym_for] = ACTIONS(423),
     [anon_sym_while] = ACTIONS(423),
     [sym_keyword_import] = ACTIONS(423),
@@ -6913,6 +7092,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(505),
     [anon_sym_fn] = ACTIONS(505),
     [anon_sym_pub] = ACTIONS(505),
+    [anon_sym_comptime] = ACTIONS(505),
     [anon_sym_error] = ACTIONS(505),
     [anon_sym_enum] = ACTIONS(505),
     [anon_sym_union] = ACTIONS(505),
@@ -6922,8 +7102,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(505),
     [anon_sym_else] = ACTIONS(505),
     [anon_sym_match] = ACTIONS(505),
-    [anon_sym_return] = ACTIONS(505),
     [anon_sym_exit] = ACTIONS(505),
+    [anon_sym_yield] = ACTIONS(505),
+    [anon_sym_is] = ACTIONS(505),
     [anon_sym_for] = ACTIONS(505),
     [anon_sym_while] = ACTIONS(505),
     [sym_keyword_import] = ACTIONS(505),
@@ -6983,6 +7164,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(441),
     [anon_sym_fn] = ACTIONS(441),
     [anon_sym_pub] = ACTIONS(441),
+    [anon_sym_comptime] = ACTIONS(441),
     [anon_sym_error] = ACTIONS(441),
     [anon_sym_enum] = ACTIONS(441),
     [anon_sym_union] = ACTIONS(441),
@@ -6992,8 +7174,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(441),
     [anon_sym_else] = ACTIONS(441),
     [anon_sym_match] = ACTIONS(441),
-    [anon_sym_return] = ACTIONS(441),
     [anon_sym_exit] = ACTIONS(441),
+    [anon_sym_yield] = ACTIONS(441),
+    [anon_sym_is] = ACTIONS(441),
     [anon_sym_for] = ACTIONS(441),
     [anon_sym_while] = ACTIONS(441),
     [sym_keyword_import] = ACTIONS(441),
@@ -7053,6 +7236,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(445),
     [anon_sym_fn] = ACTIONS(445),
     [anon_sym_pub] = ACTIONS(445),
+    [anon_sym_comptime] = ACTIONS(445),
     [anon_sym_error] = ACTIONS(445),
     [anon_sym_enum] = ACTIONS(445),
     [anon_sym_union] = ACTIONS(445),
@@ -7062,8 +7246,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(445),
     [anon_sym_else] = ACTIONS(445),
     [anon_sym_match] = ACTIONS(445),
-    [anon_sym_return] = ACTIONS(445),
     [anon_sym_exit] = ACTIONS(445),
+    [anon_sym_yield] = ACTIONS(445),
+    [anon_sym_is] = ACTIONS(445),
     [anon_sym_for] = ACTIONS(445),
     [anon_sym_while] = ACTIONS(445),
     [sym_keyword_import] = ACTIONS(445),
@@ -7123,6 +7308,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(501),
     [anon_sym_fn] = ACTIONS(501),
     [anon_sym_pub] = ACTIONS(501),
+    [anon_sym_comptime] = ACTIONS(501),
     [anon_sym_error] = ACTIONS(501),
     [anon_sym_enum] = ACTIONS(501),
     [anon_sym_union] = ACTIONS(501),
@@ -7132,8 +7318,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(501),
     [anon_sym_else] = ACTIONS(501),
     [anon_sym_match] = ACTIONS(501),
-    [anon_sym_return] = ACTIONS(501),
     [anon_sym_exit] = ACTIONS(501),
+    [anon_sym_yield] = ACTIONS(501),
+    [anon_sym_is] = ACTIONS(501),
     [anon_sym_for] = ACTIONS(501),
     [anon_sym_while] = ACTIONS(501),
     [sym_keyword_import] = ACTIONS(501),
@@ -7193,6 +7380,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(465),
     [anon_sym_fn] = ACTIONS(465),
     [anon_sym_pub] = ACTIONS(465),
+    [anon_sym_comptime] = ACTIONS(465),
     [anon_sym_error] = ACTIONS(465),
     [anon_sym_enum] = ACTIONS(465),
     [anon_sym_union] = ACTIONS(465),
@@ -7202,8 +7390,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(465),
     [anon_sym_else] = ACTIONS(465),
     [anon_sym_match] = ACTIONS(465),
-    [anon_sym_return] = ACTIONS(465),
     [anon_sym_exit] = ACTIONS(465),
+    [anon_sym_yield] = ACTIONS(465),
+    [anon_sym_is] = ACTIONS(465),
     [anon_sym_for] = ACTIONS(465),
     [anon_sym_while] = ACTIONS(465),
     [sym_keyword_import] = ACTIONS(465),
@@ -7263,6 +7452,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(485),
     [anon_sym_fn] = ACTIONS(485),
     [anon_sym_pub] = ACTIONS(485),
+    [anon_sym_comptime] = ACTIONS(485),
     [anon_sym_error] = ACTIONS(485),
     [anon_sym_enum] = ACTIONS(485),
     [anon_sym_union] = ACTIONS(485),
@@ -7272,8 +7462,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(485),
     [anon_sym_else] = ACTIONS(485),
     [anon_sym_match] = ACTIONS(485),
-    [anon_sym_return] = ACTIONS(485),
     [anon_sym_exit] = ACTIONS(485),
+    [anon_sym_yield] = ACTIONS(485),
+    [anon_sym_is] = ACTIONS(485),
     [anon_sym_for] = ACTIONS(485),
     [anon_sym_while] = ACTIONS(485),
     [sym_keyword_import] = ACTIONS(485),
@@ -7333,6 +7524,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(473),
     [anon_sym_fn] = ACTIONS(473),
     [anon_sym_pub] = ACTIONS(473),
+    [anon_sym_comptime] = ACTIONS(473),
     [anon_sym_error] = ACTIONS(473),
     [anon_sym_enum] = ACTIONS(473),
     [anon_sym_union] = ACTIONS(473),
@@ -7342,8 +7534,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(473),
     [anon_sym_else] = ACTIONS(473),
     [anon_sym_match] = ACTIONS(473),
-    [anon_sym_return] = ACTIONS(473),
     [anon_sym_exit] = ACTIONS(473),
+    [anon_sym_yield] = ACTIONS(473),
+    [anon_sym_is] = ACTIONS(473),
     [anon_sym_for] = ACTIONS(473),
     [anon_sym_while] = ACTIONS(473),
     [sym_keyword_import] = ACTIONS(473),
@@ -7403,6 +7596,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(509),
     [anon_sym_fn] = ACTIONS(509),
     [anon_sym_pub] = ACTIONS(509),
+    [anon_sym_comptime] = ACTIONS(509),
     [anon_sym_error] = ACTIONS(509),
     [anon_sym_enum] = ACTIONS(509),
     [anon_sym_union] = ACTIONS(509),
@@ -7412,8 +7606,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(509),
     [anon_sym_else] = ACTIONS(509),
     [anon_sym_match] = ACTIONS(509),
-    [anon_sym_return] = ACTIONS(509),
     [anon_sym_exit] = ACTIONS(509),
+    [anon_sym_yield] = ACTIONS(509),
+    [anon_sym_is] = ACTIONS(509),
     [anon_sym_for] = ACTIONS(509),
     [anon_sym_while] = ACTIONS(509),
     [sym_keyword_import] = ACTIONS(509),
@@ -7473,6 +7668,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(469),
     [anon_sym_fn] = ACTIONS(469),
     [anon_sym_pub] = ACTIONS(469),
+    [anon_sym_comptime] = ACTIONS(469),
     [anon_sym_error] = ACTIONS(469),
     [anon_sym_enum] = ACTIONS(469),
     [anon_sym_union] = ACTIONS(469),
@@ -7482,8 +7678,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(469),
     [anon_sym_else] = ACTIONS(469),
     [anon_sym_match] = ACTIONS(469),
-    [anon_sym_return] = ACTIONS(469),
     [anon_sym_exit] = ACTIONS(469),
+    [anon_sym_yield] = ACTIONS(469),
+    [anon_sym_is] = ACTIONS(469),
     [anon_sym_for] = ACTIONS(469),
     [anon_sym_while] = ACTIONS(469),
     [sym_keyword_import] = ACTIONS(469),
@@ -7543,6 +7740,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(437),
     [anon_sym_fn] = ACTIONS(437),
     [anon_sym_pub] = ACTIONS(437),
+    [anon_sym_comptime] = ACTIONS(437),
     [anon_sym_error] = ACTIONS(437),
     [anon_sym_enum] = ACTIONS(437),
     [anon_sym_union] = ACTIONS(437),
@@ -7552,8 +7750,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(437),
     [anon_sym_else] = ACTIONS(437),
     [anon_sym_match] = ACTIONS(437),
-    [anon_sym_return] = ACTIONS(437),
     [anon_sym_exit] = ACTIONS(437),
+    [anon_sym_yield] = ACTIONS(437),
+    [anon_sym_is] = ACTIONS(437),
     [anon_sym_for] = ACTIONS(437),
     [anon_sym_while] = ACTIONS(437),
     [sym_keyword_import] = ACTIONS(437),
@@ -7613,6 +7812,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(489),
     [anon_sym_fn] = ACTIONS(489),
     [anon_sym_pub] = ACTIONS(489),
+    [anon_sym_comptime] = ACTIONS(489),
     [anon_sym_error] = ACTIONS(489),
     [anon_sym_enum] = ACTIONS(489),
     [anon_sym_union] = ACTIONS(489),
@@ -7622,8 +7822,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(489),
     [anon_sym_else] = ACTIONS(489),
     [anon_sym_match] = ACTIONS(489),
-    [anon_sym_return] = ACTIONS(489),
     [anon_sym_exit] = ACTIONS(489),
+    [anon_sym_yield] = ACTIONS(489),
+    [anon_sym_is] = ACTIONS(489),
     [anon_sym_for] = ACTIONS(489),
     [anon_sym_while] = ACTIONS(489),
     [sym_keyword_import] = ACTIONS(489),
@@ -7683,6 +7884,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(449),
     [anon_sym_fn] = ACTIONS(449),
     [anon_sym_pub] = ACTIONS(449),
+    [anon_sym_comptime] = ACTIONS(449),
     [anon_sym_error] = ACTIONS(449),
     [anon_sym_enum] = ACTIONS(449),
     [anon_sym_union] = ACTIONS(449),
@@ -7692,8 +7894,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(449),
     [anon_sym_else] = ACTIONS(449),
     [anon_sym_match] = ACTIONS(449),
-    [anon_sym_return] = ACTIONS(449),
     [anon_sym_exit] = ACTIONS(449),
+    [anon_sym_yield] = ACTIONS(449),
+    [anon_sym_is] = ACTIONS(449),
     [anon_sym_for] = ACTIONS(449),
     [anon_sym_while] = ACTIONS(449),
     [sym_keyword_import] = ACTIONS(449),
@@ -7753,6 +7956,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(457),
     [anon_sym_fn] = ACTIONS(457),
     [anon_sym_pub] = ACTIONS(457),
+    [anon_sym_comptime] = ACTIONS(457),
     [anon_sym_error] = ACTIONS(457),
     [anon_sym_enum] = ACTIONS(457),
     [anon_sym_union] = ACTIONS(457),
@@ -7762,8 +7966,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(457),
     [anon_sym_else] = ACTIONS(457),
     [anon_sym_match] = ACTIONS(457),
-    [anon_sym_return] = ACTIONS(457),
     [anon_sym_exit] = ACTIONS(457),
+    [anon_sym_yield] = ACTIONS(457),
+    [anon_sym_is] = ACTIONS(457),
     [anon_sym_for] = ACTIONS(457),
     [anon_sym_while] = ACTIONS(457),
     [sym_keyword_import] = ACTIONS(457),
@@ -7823,6 +8028,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(429),
     [anon_sym_fn] = ACTIONS(429),
     [anon_sym_pub] = ACTIONS(429),
+    [anon_sym_comptime] = ACTIONS(429),
     [anon_sym_error] = ACTIONS(429),
     [anon_sym_enum] = ACTIONS(429),
     [anon_sym_union] = ACTIONS(429),
@@ -7832,8 +8038,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(429),
     [anon_sym_else] = ACTIONS(429),
     [anon_sym_match] = ACTIONS(429),
-    [anon_sym_return] = ACTIONS(429),
     [anon_sym_exit] = ACTIONS(429),
+    [anon_sym_yield] = ACTIONS(429),
+    [anon_sym_is] = ACTIONS(429),
     [anon_sym_for] = ACTIONS(429),
     [anon_sym_while] = ACTIONS(429),
     [sym_keyword_import] = ACTIONS(429),
@@ -7893,6 +8100,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(481),
     [anon_sym_fn] = ACTIONS(481),
     [anon_sym_pub] = ACTIONS(481),
+    [anon_sym_comptime] = ACTIONS(481),
     [anon_sym_error] = ACTIONS(481),
     [anon_sym_enum] = ACTIONS(481),
     [anon_sym_union] = ACTIONS(481),
@@ -7902,8 +8110,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(481),
     [anon_sym_else] = ACTIONS(481),
     [anon_sym_match] = ACTIONS(481),
-    [anon_sym_return] = ACTIONS(481),
     [anon_sym_exit] = ACTIONS(481),
+    [anon_sym_yield] = ACTIONS(481),
+    [anon_sym_is] = ACTIONS(481),
     [anon_sym_for] = ACTIONS(481),
     [anon_sym_while] = ACTIONS(481),
     [sym_keyword_import] = ACTIONS(481),
@@ -7961,6 +8170,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(497),
     [anon_sym_fn] = ACTIONS(497),
     [anon_sym_pub] = ACTIONS(497),
+    [anon_sym_comptime] = ACTIONS(497),
     [anon_sym_error] = ACTIONS(497),
     [anon_sym_enum] = ACTIONS(497),
     [anon_sym_union] = ACTIONS(497),
@@ -7970,8 +8180,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(497),
     [anon_sym_else] = ACTIONS(497),
     [anon_sym_match] = ACTIONS(497),
-    [anon_sym_return] = ACTIONS(497),
     [anon_sym_exit] = ACTIONS(497),
+    [anon_sym_yield] = ACTIONS(497),
+    [anon_sym_is] = ACTIONS(497),
     [anon_sym_for] = ACTIONS(497),
     [anon_sym_while] = ACTIONS(497),
     [sym_keyword_import] = ACTIONS(497),
@@ -8029,6 +8240,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(469),
     [anon_sym_fn] = ACTIONS(469),
     [anon_sym_pub] = ACTIONS(469),
+    [anon_sym_comptime] = ACTIONS(469),
     [anon_sym_error] = ACTIONS(469),
     [anon_sym_enum] = ACTIONS(469),
     [anon_sym_union] = ACTIONS(469),
@@ -8038,8 +8250,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(469),
     [anon_sym_else] = ACTIONS(469),
     [anon_sym_match] = ACTIONS(469),
-    [anon_sym_return] = ACTIONS(469),
     [anon_sym_exit] = ACTIONS(469),
+    [anon_sym_yield] = ACTIONS(469),
+    [anon_sym_is] = ACTIONS(469),
     [anon_sym_for] = ACTIONS(469),
     [anon_sym_while] = ACTIONS(469),
     [sym_keyword_import] = ACTIONS(469),
@@ -8097,6 +8310,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(489),
     [anon_sym_fn] = ACTIONS(489),
     [anon_sym_pub] = ACTIONS(489),
+    [anon_sym_comptime] = ACTIONS(489),
     [anon_sym_error] = ACTIONS(489),
     [anon_sym_enum] = ACTIONS(489),
     [anon_sym_union] = ACTIONS(489),
@@ -8106,8 +8320,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(489),
     [anon_sym_else] = ACTIONS(489),
     [anon_sym_match] = ACTIONS(489),
-    [anon_sym_return] = ACTIONS(489),
     [anon_sym_exit] = ACTIONS(489),
+    [anon_sym_yield] = ACTIONS(489),
+    [anon_sym_is] = ACTIONS(489),
     [anon_sym_for] = ACTIONS(489),
     [anon_sym_while] = ACTIONS(489),
     [sym_keyword_import] = ACTIONS(489),
@@ -8165,6 +8380,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(449),
     [anon_sym_fn] = ACTIONS(449),
     [anon_sym_pub] = ACTIONS(449),
+    [anon_sym_comptime] = ACTIONS(449),
     [anon_sym_error] = ACTIONS(449),
     [anon_sym_enum] = ACTIONS(449),
     [anon_sym_union] = ACTIONS(449),
@@ -8174,8 +8390,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(449),
     [anon_sym_else] = ACTIONS(449),
     [anon_sym_match] = ACTIONS(449),
-    [anon_sym_return] = ACTIONS(449),
     [anon_sym_exit] = ACTIONS(449),
+    [anon_sym_yield] = ACTIONS(449),
+    [anon_sym_is] = ACTIONS(449),
     [anon_sym_for] = ACTIONS(449),
     [anon_sym_while] = ACTIONS(449),
     [sym_keyword_import] = ACTIONS(449),
@@ -8233,6 +8450,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(457),
     [anon_sym_fn] = ACTIONS(457),
     [anon_sym_pub] = ACTIONS(457),
+    [anon_sym_comptime] = ACTIONS(457),
     [anon_sym_error] = ACTIONS(457),
     [anon_sym_enum] = ACTIONS(457),
     [anon_sym_union] = ACTIONS(457),
@@ -8242,8 +8460,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(457),
     [anon_sym_else] = ACTIONS(457),
     [anon_sym_match] = ACTIONS(457),
-    [anon_sym_return] = ACTIONS(457),
     [anon_sym_exit] = ACTIONS(457),
+    [anon_sym_yield] = ACTIONS(457),
+    [anon_sym_is] = ACTIONS(457),
     [anon_sym_for] = ACTIONS(457),
     [anon_sym_while] = ACTIONS(457),
     [sym_keyword_import] = ACTIONS(457),
@@ -8301,6 +8520,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(429),
     [anon_sym_fn] = ACTIONS(429),
     [anon_sym_pub] = ACTIONS(429),
+    [anon_sym_comptime] = ACTIONS(429),
     [anon_sym_error] = ACTIONS(429),
     [anon_sym_enum] = ACTIONS(429),
     [anon_sym_union] = ACTIONS(429),
@@ -8310,8 +8530,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(429),
     [anon_sym_else] = ACTIONS(429),
     [anon_sym_match] = ACTIONS(429),
-    [anon_sym_return] = ACTIONS(429),
     [anon_sym_exit] = ACTIONS(429),
+    [anon_sym_yield] = ACTIONS(429),
+    [anon_sym_is] = ACTIONS(429),
     [anon_sym_for] = ACTIONS(429),
     [anon_sym_while] = ACTIONS(429),
     [sym_keyword_import] = ACTIONS(429),
@@ -8369,6 +8590,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(493),
     [anon_sym_fn] = ACTIONS(493),
     [anon_sym_pub] = ACTIONS(493),
+    [anon_sym_comptime] = ACTIONS(493),
     [anon_sym_error] = ACTIONS(493),
     [anon_sym_enum] = ACTIONS(493),
     [anon_sym_union] = ACTIONS(493),
@@ -8378,8 +8600,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(493),
     [anon_sym_else] = ACTIONS(493),
     [anon_sym_match] = ACTIONS(493),
-    [anon_sym_return] = ACTIONS(493),
     [anon_sym_exit] = ACTIONS(493),
+    [anon_sym_yield] = ACTIONS(493),
+    [anon_sym_is] = ACTIONS(493),
     [anon_sym_for] = ACTIONS(493),
     [anon_sym_while] = ACTIONS(493),
     [sym_keyword_import] = ACTIONS(493),
@@ -8437,6 +8660,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(423),
     [anon_sym_fn] = ACTIONS(423),
     [anon_sym_pub] = ACTIONS(423),
+    [anon_sym_comptime] = ACTIONS(423),
     [anon_sym_error] = ACTIONS(423),
     [anon_sym_enum] = ACTIONS(423),
     [anon_sym_union] = ACTIONS(423),
@@ -8446,8 +8670,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(423),
     [anon_sym_else] = ACTIONS(423),
     [anon_sym_match] = ACTIONS(423),
-    [anon_sym_return] = ACTIONS(423),
     [anon_sym_exit] = ACTIONS(423),
+    [anon_sym_yield] = ACTIONS(423),
+    [anon_sym_is] = ACTIONS(423),
     [anon_sym_for] = ACTIONS(423),
     [anon_sym_while] = ACTIONS(423),
     [sym_keyword_import] = ACTIONS(423),
@@ -8505,6 +8730,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(505),
     [anon_sym_fn] = ACTIONS(505),
     [anon_sym_pub] = ACTIONS(505),
+    [anon_sym_comptime] = ACTIONS(505),
     [anon_sym_error] = ACTIONS(505),
     [anon_sym_enum] = ACTIONS(505),
     [anon_sym_union] = ACTIONS(505),
@@ -8514,8 +8740,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(505),
     [anon_sym_else] = ACTIONS(505),
     [anon_sym_match] = ACTIONS(505),
-    [anon_sym_return] = ACTIONS(505),
     [anon_sym_exit] = ACTIONS(505),
+    [anon_sym_yield] = ACTIONS(505),
+    [anon_sym_is] = ACTIONS(505),
     [anon_sym_for] = ACTIONS(505),
     [anon_sym_while] = ACTIONS(505),
     [sym_keyword_import] = ACTIONS(505),
@@ -8573,6 +8800,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(441),
     [anon_sym_fn] = ACTIONS(441),
     [anon_sym_pub] = ACTIONS(441),
+    [anon_sym_comptime] = ACTIONS(441),
     [anon_sym_error] = ACTIONS(441),
     [anon_sym_enum] = ACTIONS(441),
     [anon_sym_union] = ACTIONS(441),
@@ -8582,8 +8810,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(441),
     [anon_sym_else] = ACTIONS(441),
     [anon_sym_match] = ACTIONS(441),
-    [anon_sym_return] = ACTIONS(441),
     [anon_sym_exit] = ACTIONS(441),
+    [anon_sym_yield] = ACTIONS(441),
+    [anon_sym_is] = ACTIONS(441),
     [anon_sym_for] = ACTIONS(441),
     [anon_sym_while] = ACTIONS(441),
     [sym_keyword_import] = ACTIONS(441),
@@ -8641,6 +8870,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(445),
     [anon_sym_fn] = ACTIONS(445),
     [anon_sym_pub] = ACTIONS(445),
+    [anon_sym_comptime] = ACTIONS(445),
     [anon_sym_error] = ACTIONS(445),
     [anon_sym_enum] = ACTIONS(445),
     [anon_sym_union] = ACTIONS(445),
@@ -8650,8 +8880,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(445),
     [anon_sym_else] = ACTIONS(445),
     [anon_sym_match] = ACTIONS(445),
-    [anon_sym_return] = ACTIONS(445),
     [anon_sym_exit] = ACTIONS(445),
+    [anon_sym_yield] = ACTIONS(445),
+    [anon_sym_is] = ACTIONS(445),
     [anon_sym_for] = ACTIONS(445),
     [anon_sym_while] = ACTIONS(445),
     [sym_keyword_import] = ACTIONS(445),
@@ -8709,6 +8940,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(465),
     [anon_sym_fn] = ACTIONS(465),
     [anon_sym_pub] = ACTIONS(465),
+    [anon_sym_comptime] = ACTIONS(465),
     [anon_sym_error] = ACTIONS(465),
     [anon_sym_enum] = ACTIONS(465),
     [anon_sym_union] = ACTIONS(465),
@@ -8718,8 +8950,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(465),
     [anon_sym_else] = ACTIONS(465),
     [anon_sym_match] = ACTIONS(465),
-    [anon_sym_return] = ACTIONS(465),
     [anon_sym_exit] = ACTIONS(465),
+    [anon_sym_yield] = ACTIONS(465),
+    [anon_sym_is] = ACTIONS(465),
     [anon_sym_for] = ACTIONS(465),
     [anon_sym_while] = ACTIONS(465),
     [sym_keyword_import] = ACTIONS(465),
@@ -8777,6 +9010,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(511),
     [anon_sym_fn] = ACTIONS(511),
     [anon_sym_pub] = ACTIONS(511),
+    [anon_sym_comptime] = ACTIONS(511),
     [anon_sym_error] = ACTIONS(511),
     [anon_sym_enum] = ACTIONS(511),
     [anon_sym_union] = ACTIONS(511),
@@ -8786,8 +9020,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(511),
     [anon_sym_else] = ACTIONS(511),
     [anon_sym_match] = ACTIONS(511),
-    [anon_sym_return] = ACTIONS(511),
     [anon_sym_exit] = ACTIONS(511),
+    [anon_sym_yield] = ACTIONS(511),
+    [anon_sym_is] = ACTIONS(511),
     [anon_sym_for] = ACTIONS(511),
     [anon_sym_while] = ACTIONS(511),
     [sym_keyword_import] = ACTIONS(511),
@@ -8845,6 +9080,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(509),
     [anon_sym_fn] = ACTIONS(509),
     [anon_sym_pub] = ACTIONS(509),
+    [anon_sym_comptime] = ACTIONS(509),
     [anon_sym_error] = ACTIONS(509),
     [anon_sym_enum] = ACTIONS(509),
     [anon_sym_union] = ACTIONS(509),
@@ -8854,8 +9090,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(509),
     [anon_sym_else] = ACTIONS(509),
     [anon_sym_match] = ACTIONS(509),
-    [anon_sym_return] = ACTIONS(509),
     [anon_sym_exit] = ACTIONS(509),
+    [anon_sym_yield] = ACTIONS(509),
+    [anon_sym_is] = ACTIONS(509),
     [anon_sym_for] = ACTIONS(509),
     [anon_sym_while] = ACTIONS(509),
     [sym_keyword_import] = ACTIONS(509),
@@ -8913,6 +9150,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(433),
     [anon_sym_fn] = ACTIONS(433),
     [anon_sym_pub] = ACTIONS(433),
+    [anon_sym_comptime] = ACTIONS(433),
     [anon_sym_error] = ACTIONS(433),
     [anon_sym_enum] = ACTIONS(433),
     [anon_sym_union] = ACTIONS(433),
@@ -8922,8 +9160,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(433),
     [anon_sym_else] = ACTIONS(433),
     [anon_sym_match] = ACTIONS(433),
-    [anon_sym_return] = ACTIONS(433),
     [anon_sym_exit] = ACTIONS(433),
+    [anon_sym_yield] = ACTIONS(433),
+    [anon_sym_is] = ACTIONS(433),
     [anon_sym_for] = ACTIONS(433),
     [anon_sym_while] = ACTIONS(433),
     [sym_keyword_import] = ACTIONS(433),
@@ -8981,6 +9220,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(437),
     [anon_sym_fn] = ACTIONS(437),
     [anon_sym_pub] = ACTIONS(437),
+    [anon_sym_comptime] = ACTIONS(437),
     [anon_sym_error] = ACTIONS(437),
     [anon_sym_enum] = ACTIONS(437),
     [anon_sym_union] = ACTIONS(437),
@@ -8990,8 +9230,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(437),
     [anon_sym_else] = ACTIONS(437),
     [anon_sym_match] = ACTIONS(437),
-    [anon_sym_return] = ACTIONS(437),
     [anon_sym_exit] = ACTIONS(437),
+    [anon_sym_yield] = ACTIONS(437),
+    [anon_sym_is] = ACTIONS(437),
     [anon_sym_for] = ACTIONS(437),
     [anon_sym_while] = ACTIONS(437),
     [sym_keyword_import] = ACTIONS(437),
@@ -9049,6 +9290,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(515),
     [anon_sym_fn] = ACTIONS(515),
     [anon_sym_pub] = ACTIONS(515),
+    [anon_sym_comptime] = ACTIONS(515),
     [anon_sym_error] = ACTIONS(515),
     [anon_sym_enum] = ACTIONS(515),
     [anon_sym_union] = ACTIONS(515),
@@ -9058,8 +9300,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(515),
     [anon_sym_else] = ACTIONS(515),
     [anon_sym_match] = ACTIONS(515),
-    [anon_sym_return] = ACTIONS(515),
     [anon_sym_exit] = ACTIONS(515),
+    [anon_sym_yield] = ACTIONS(515),
+    [anon_sym_is] = ACTIONS(515),
     [anon_sym_for] = ACTIONS(515),
     [anon_sym_while] = ACTIONS(515),
     [sym_keyword_import] = ACTIONS(515),
@@ -9117,6 +9360,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(519),
     [anon_sym_fn] = ACTIONS(519),
     [anon_sym_pub] = ACTIONS(519),
+    [anon_sym_comptime] = ACTIONS(519),
     [anon_sym_error] = ACTIONS(519),
     [anon_sym_enum] = ACTIONS(519),
     [anon_sym_union] = ACTIONS(519),
@@ -9126,8 +9370,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(519),
     [anon_sym_else] = ACTIONS(519),
     [anon_sym_match] = ACTIONS(519),
-    [anon_sym_return] = ACTIONS(519),
     [anon_sym_exit] = ACTIONS(519),
+    [anon_sym_yield] = ACTIONS(519),
+    [anon_sym_is] = ACTIONS(519),
     [anon_sym_for] = ACTIONS(519),
     [anon_sym_while] = ACTIONS(519),
     [sym_keyword_import] = ACTIONS(519),
@@ -9185,6 +9430,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(523),
     [anon_sym_fn] = ACTIONS(523),
     [anon_sym_pub] = ACTIONS(523),
+    [anon_sym_comptime] = ACTIONS(523),
     [anon_sym_error] = ACTIONS(523),
     [anon_sym_enum] = ACTIONS(523),
     [anon_sym_union] = ACTIONS(523),
@@ -9194,8 +9440,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(523),
     [anon_sym_else] = ACTIONS(523),
     [anon_sym_match] = ACTIONS(523),
-    [anon_sym_return] = ACTIONS(523),
     [anon_sym_exit] = ACTIONS(523),
+    [anon_sym_yield] = ACTIONS(523),
+    [anon_sym_is] = ACTIONS(523),
     [anon_sym_for] = ACTIONS(523),
     [anon_sym_while] = ACTIONS(523),
     [sym_keyword_import] = ACTIONS(523),
@@ -9253,6 +9500,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(527),
     [anon_sym_fn] = ACTIONS(527),
     [anon_sym_pub] = ACTIONS(527),
+    [anon_sym_comptime] = ACTIONS(527),
     [anon_sym_error] = ACTIONS(527),
     [anon_sym_enum] = ACTIONS(527),
     [anon_sym_union] = ACTIONS(527),
@@ -9262,8 +9510,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(527),
     [anon_sym_else] = ACTIONS(527),
     [anon_sym_match] = ACTIONS(527),
-    [anon_sym_return] = ACTIONS(527),
     [anon_sym_exit] = ACTIONS(527),
+    [anon_sym_yield] = ACTIONS(527),
+    [anon_sym_is] = ACTIONS(527),
     [anon_sym_for] = ACTIONS(527),
     [anon_sym_while] = ACTIONS(527),
     [sym_keyword_import] = ACTIONS(527),
@@ -9321,6 +9570,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(531),
     [anon_sym_fn] = ACTIONS(531),
     [anon_sym_pub] = ACTIONS(531),
+    [anon_sym_comptime] = ACTIONS(531),
     [anon_sym_error] = ACTIONS(531),
     [anon_sym_enum] = ACTIONS(531),
     [anon_sym_union] = ACTIONS(531),
@@ -9330,8 +9580,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(531),
     [anon_sym_else] = ACTIONS(531),
     [anon_sym_match] = ACTIONS(531),
-    [anon_sym_return] = ACTIONS(531),
     [anon_sym_exit] = ACTIONS(531),
+    [anon_sym_yield] = ACTIONS(531),
+    [anon_sym_is] = ACTIONS(531),
     [anon_sym_for] = ACTIONS(531),
     [anon_sym_while] = ACTIONS(531),
     [sym_keyword_import] = ACTIONS(531),
@@ -9389,6 +9640,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(535),
     [anon_sym_fn] = ACTIONS(535),
     [anon_sym_pub] = ACTIONS(535),
+    [anon_sym_comptime] = ACTIONS(535),
     [anon_sym_error] = ACTIONS(535),
     [anon_sym_enum] = ACTIONS(535),
     [anon_sym_union] = ACTIONS(535),
@@ -9398,8 +9650,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(535),
     [anon_sym_else] = ACTIONS(535),
     [anon_sym_match] = ACTIONS(535),
-    [anon_sym_return] = ACTIONS(535),
     [anon_sym_exit] = ACTIONS(535),
+    [anon_sym_yield] = ACTIONS(535),
+    [anon_sym_is] = ACTIONS(535),
     [anon_sym_for] = ACTIONS(535),
     [anon_sym_while] = ACTIONS(535),
     [sym_keyword_import] = ACTIONS(535),
@@ -9457,6 +9710,7 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_var] = ACTIONS(539),
     [anon_sym_fn] = ACTIONS(539),
     [anon_sym_pub] = ACTIONS(539),
+    [anon_sym_comptime] = ACTIONS(539),
     [anon_sym_error] = ACTIONS(539),
     [anon_sym_enum] = ACTIONS(539),
     [anon_sym_union] = ACTIONS(539),
@@ -9466,8 +9720,9 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_if] = ACTIONS(539),
     [anon_sym_else] = ACTIONS(539),
     [anon_sym_match] = ACTIONS(539),
-    [anon_sym_return] = ACTIONS(539),
     [anon_sym_exit] = ACTIONS(539),
+    [anon_sym_yield] = ACTIONS(539),
+    [anon_sym_is] = ACTIONS(539),
     [anon_sym_for] = ACTIONS(539),
     [anon_sym_while] = ACTIONS(539),
     [sym_keyword_import] = ACTIONS(539),
@@ -10535,6 +10790,7 @@ TS_PUBLIC const TSLanguage *tree_sitter_runic(void) {
     .state_count = STATE_COUNT,
     .large_state_count = LARGE_STATE_COUNT,
     .production_id_count = PRODUCTION_ID_COUNT,
+    .supertype_count = SUPERTYPE_COUNT,
     .field_count = FIELD_COUNT,
     .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,
     .parse_table = &ts_parse_table[0][0],
@@ -10551,6 +10807,13 @@ TS_PUBLIC const TSLanguage *tree_sitter_runic(void) {
     .keyword_lex_fn = ts_lex_keywords,
     .keyword_capture_token = sym_identifier,
     .primary_state_ids = ts_primary_state_ids,
+    .name = "runic",
+    .max_reserved_word_set_size = 0,
+    .metadata = {
+      .major_version = 0,
+      .minor_version = 0,
+      .patch_version = 1,
+    },
   };
   return &language;
 }

--- a/editor/neovim/tree-sitter/src/parser.c
+++ b/editor/neovim/tree-sitter/src/parser.c
@@ -6,7 +6,7 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
-#define LANGUAGE_VERSION 15
+#define LANGUAGE_VERSION 14
 #define STATE_COUNT 138
 #define LARGE_STATE_COUNT 97
 #define SYMBOL_COUNT 113
@@ -2155,7 +2155,7 @@ static bool ts_lex_keywords(TSLexer *lexer, TSStateId state) {
   }
 }
 
-static const TSLexerMode ts_lex_modes[STATE_COUNT] = {
+static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
   [1] = {.lex_state = 25},
   [2] = {.lex_state = 25},
@@ -10790,7 +10790,6 @@ TS_PUBLIC const TSLanguage *tree_sitter_runic(void) {
     .state_count = STATE_COUNT,
     .large_state_count = LARGE_STATE_COUNT,
     .production_id_count = PRODUCTION_ID_COUNT,
-    .supertype_count = SUPERTYPE_COUNT,
     .field_count = FIELD_COUNT,
     .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,
     .parse_table = &ts_parse_table[0][0],
@@ -10807,13 +10806,6 @@ TS_PUBLIC const TSLanguage *tree_sitter_runic(void) {
     .keyword_lex_fn = ts_lex_keywords,
     .keyword_capture_token = sym_identifier,
     .primary_state_ids = ts_primary_state_ids,
-    .name = "runic",
-    .max_reserved_word_set_size = 0,
-    .metadata = {
-      .major_version = 0,
-      .minor_version = 0,
-      .patch_version = 1,
-    },
   };
   return &language;
 }

--- a/future/c-ffi.md
+++ b/future/c-ffi.md
@@ -1,0 +1,332 @@
+# C FFI: importing dynamic libraries
+
+## Introduction
+
+Runic scripts should be able to load a C dynamic library (`.so`/`.dylib`/`.dll`)
+and call functions in it. Zig's C interop makes the pieces available — runtime
+dynamic loading via `std.DynLib`, and the C calling convention via
+`callconv(.c)` — but there is one real obstacle that shapes the whole design,
+covered next.
+
+This is a scoping document, not an implementation plan. It sketches the syntax,
+the type model, the calling mechanism, the integration points, and a phased
+rollout, and flags the open questions.
+
+## Goals
+
+- `import` a system or local C library and call scalar functions from it
+  (`libm`'s `cos`/`pow`, a project's own `.so`, etc.).
+- A declared, type-checked interface so calls are checked like any other Runic
+  call and so the runtime knows how to marshal arguments.
+- No *runtime* third-party dependency: the C-calling backend (`libffi`) is
+  vendored and statically linked, so it ships inside the `runic` binary and
+  end users install nothing.
+
+## Non-goals (at least initially)
+
+- Passing/returning C structs *by value*, `union`s, or variadic functions.
+  `libffi` can *call* these, so the limit is the marshalling side (describing a
+  struct's layout as an `ffi_type` and mapping it to/from a Runic value), which
+  is deferred rather than blocked by the calling mechanism.
+- C callbacks (passing a Runic function as a C function pointer).
+- Compile-time `@cImport` of headers. Runic is interpreted; there is no Zig
+  compile step per script, so the C interface is described in the script, not
+  parsed from a header.
+- Automatic memory ownership across the boundary (see *Ownership & safety*).
+
+## The core challenge
+
+`dlsym` (via `std.DynLib.lookup`) returns an **address**. To *call* it, the
+compiler must know the function's *type* (arity, argument classes, return
+class) so it can emit the platform ABI (which registers/stack slots the
+arguments go in). In Zig that type is required at **comptime**:
+
+```zig
+pub fn lookup(self: *DynLib, comptime T: type, name: [:0]const u8) ?T
+```
+
+But in an interpreted language the signature is only known at **runtime** (it
+comes from the script). So we cannot simply cast the address to "the function
+type the script declared" and call it — that type does not exist at Zig compile
+time. Everything below is really about bridging that gap.
+
+## Design
+
+### 1. Loading a library
+
+`std.DynLib.open(path)` / `.openZ(pathZ)` wraps `dlopen`; `.lookup` wraps
+`dlsym`; `.close` wraps `dlclose`. Library handles are long-lived process
+resources — they fit the existing `closeable` value/resource model
+(`src/ir/value.zig`, `src/closeable.zig`) so they are closed at script exit.
+
+Path resolution needs its own rule, distinct from `resolveModulePath`
+(`src/frontend/document_store.zig`), because C libraries are found differently
+from `.rn` modules:
+
+- a bare soname (`"libm.so.6"`, `"libSDL2.so"`) → hand to `dlopen`, which uses
+  the system loader search path (`LD_LIBRARY_PATH`, `/etc/ld.so.cache`, …);
+- a relative/absolute path (`"./native/mylib.so"`) → resolve against the
+  importing script's directory, like module imports.
+
+### 2. Declaring the interface
+
+A C library carries no Runic type information, so the script declares the
+functions it will call. A dedicated form keeps this separate from the Runic
+module import and from the stream-typed `fn StdinType name(...) StdoutType`
+signature (C functions have no stdin/stdout stream notion):
+
+```rn
+const m = cimport "libm.so.6" {
+    extern fn cos(x: CDouble) CDouble
+    extern fn pow(base: CDouble, exp: CDouble) CDouble
+}
+
+echo "${m.cos 0.0}"        // 1
+echo "${m.pow 2.0 10.0}"   // 1024
+```
+
+The result binds like a module value: `m.cos`, `m.pow` are members resolved the
+same way module members are today (`compileMember` /
+`resolveMemberFieldSpan`). Each `extern fn` records: the symbol name, the
+ordered parameter C-types, and the return C-type.
+
+The declared C types are a small, explicit set so the ABI is unambiguous
+(Runic `Int` is 64-bit, C `int` is 32-bit — conflating them is a real bug
+source, so the interface names the C width directly):
+
+| C type    | passed as                | from / to Runic value        |
+|-----------|--------------------------|------------------------------|
+| `CInt`    | 32-bit int (GP)          | `Int` (i64, truncated/checked) |
+| `CLong`   | 64-bit int (GP)          | `Int`                        |
+| `CFloat`  | 32-bit float (SSE)       | `Float` (f64)                |
+| `CDouble` | 64-bit float (SSE)       | `Float`                      |
+| `CBool`   | int 0/1 (GP)             | `Bool`                       |
+| `CStr`    | `[*:0]const u8` (GP)     | `String`                     |
+| `CPtr`    | pointer (GP)             | opaque handle (`addr`)       |
+| `CVoid`   | void return              | `Void`                       |
+
+### 3. Marshalling
+
+- **`CStr` in:** Runic strings are `addr+len` byte slices in arena memory
+  (`Value.Slice`), not null-terminated. Marshalling allocates a
+  null-terminated copy for the call and frees it after (the callee must not
+  retain it — document as a rule).
+- **`CStr` out:** a returned `char*` is copied into a fresh Runic `String`.
+  Runic never `free`s it (C owns it); functions returning heap strings the
+  caller must free are simply not safe to expose this way in the MVP.
+- **`CPtr`:** modeled as an opaque `addr` value — passable back into other
+  `extern fn`s but not dereferenceable from Runic. Enables handle-style APIs
+  (`open` → handle → `use handle` → `close handle`).
+- **Numbers/bools:** direct, with `CInt` range-checked against i64.
+
+### 4. Calling — statically linked libffi
+
+**Primary mechanism: `libffi`, vendored and statically linked.** `libffi`
+builds a call interface (`ffi_cif`) from a *runtime* type list and performs the
+call (`ffi_call`) — exactly the runtime-signature problem this whole document
+is about, solved portably and battle-tested (it backs Python `ctypes`, Ruby
+FFI, and others). It handles any arity, struct-by-value, and varargs.
+
+By compiling `libffi` from vendored source and linking it into the `runic`
+binary (Zig's build system compiles C directly), it becomes a **build/dev
+dependency, not a runtime one** — end users install nothing, and there is no
+`libffi.so` to find at script-run time. Licensing permits this: `libffi` is
+under a permissive MIT-style license, so static linking and redistribution are
+fine.
+
+This gives one code path with the full feature set from the start, and — most
+importantly — we never hand-write calling-convention code that could be subtly
+wrong per ABI (the single biggest risk otherwise; see *Open questions*). At each
+`extern fn` we build (and cache) an `ffi_cif` from the declared C-types once,
+then per call marshal the Runic `Value`s into a scratch buffer, hand `ffi_call`
+the address + the argument-pointer array, and convert the return slot back to a
+`Value`.
+
+The one real cost is the build: `libffi` is not pure C — it carries
+per-architecture assembly (`unix64.S`, `sysv.S`, …) and configure-generated
+headers (`fficonfig.h`, `ffitarget.h`) that differ per target. Vendoring it
+means committing those pre-generated headers for each supported target and
+selecting the right `.S` per arch in `build.zig` — a bounded but real
+per-target matrix to maintain, and the thing that erodes Zig's otherwise
+trivial cross-compilation. Existing `build.zig` ports of `libffi` do exactly
+this; whether a maintained Zig package for it exists should be checked before
+hand-vendoring (see *Open questions*).
+
+**Optional pure-Zig fallback: comptime trampolines.** If the vendored-libffi
+build friction (or a target libffi's matrix does not cover) ever justifies it,
+the calling step can be swapped for a dependency-free pure-Zig path: reduce
+every argument to its ABI *class* — on SysV AMD64 / AArch64 AAPCS,
+integer/pointer/bool/string pass in general-purpose registers and float/double
+in SSE/vector registers — so a signature collapses to an *ordered GP/SSE
+sequence plus a return class*. Up to arity 6 that is only
+`sum(2^n for n in 0..6) = 127` argument sequences × 3 return classes ≈ **~380**
+distinct shims, which Zig generates at comptime; the runtime picks one by the
+declared signature, `@ptrCast`s the `dlsym` address to it, and calls. It covers
+all *scalar* signatures but **excludes** struct-by-value and varargs (their ABI
+classification is not a simple GP/SSE split), so it is a fallback, not a
+replacement. Because both mechanisms consume the same `extern fn` declarations
+and the same marshalling layer, only the final dispatch step differs — the
+choice can be revisited without touching the rest of the design.
+
+### 5. Return values, errors, ownership, safety
+
+- Calling C is inherently unsafe: a wrong signature, a bad pointer, or a
+  library bug can corrupt or crash the process, and Runic cannot catch a
+  segfault. The declared-interface + explicit-C-type approach narrows the
+  footgun (no guessed signatures) but does not remove it. `cimport` should be
+  understood as an unsafe escape hatch, and probably gated the way other
+  privileged operations are (e.g. off in a future `--safe`/sandboxed mode).
+- A `dlopen`/`dlsym` failure (missing library or symbol) is a clean, catchable
+  runtime error, distinct from a crash inside a call.
+- Ownership across the boundary is manual and, in the MVP, deliberately
+  restricted (no Runic-side `free` of C returns; strings copied in/out). Richer
+  ownership (e.g. handing struct memory across) comes with struct support.
+
+## Integration points
+
+- **Lexer/parser** (`src/frontend/`): a `cimport` keyword + an `extern fn`
+  declaration block (a new AST node — it is *not* a normal `FunctionDecl`, since
+  there is no body and the parameter types are C types).
+- **Type checker** (`src/semantic/type-checker.zig`): give the `cimport` value a
+  module-like type whose members are the declared externs, so `m.cos x` type-
+  checks (argument arity/types against the C-type list, result type from the
+  return C-type). Reuses the module-member machinery.
+- **IR** (`src/ir/instruction.zig`, `src/ir/compiler.zig`): a new instruction to
+  (a) open a library and (b) call an extern by symbol with a marshalled argument
+  set; `compileImportExpr` gets a sibling `compileCImport`.
+- **Runtime** (`src/ir/evaluator.zig`, `src/ir/value.zig`, `src/closeable.zig`):
+  a `dynlib` value/handle (closeable), the marshalling of `Value` ↔ C, the
+  cached `ffi_cif` per extern, and the `ffi_call` itself.
+- **Runtime shared** (`src/runtime/`): the C-type ↔ `ffi_type` mapping lives
+  here so the compiler and evaluator agree.
+- **Build** (`build.zig`, a vendored `libffi` tree): compile `libffi` from
+  source and statically link it into `runic` and `runic-lsp`. This carries the
+  per-target header/asm selection described in *Calling*.
+
+## Binding generation
+
+Writing an `extern fn` by hand for every export is fine for `libm` but
+miserable for a library like SDL2 (hundreds of functions). A generator command
+should produce the binding file, so the manual `cimport` block is only ever a
+starting point or an override.
+
+### Where the types come from
+
+A callable binding needs each function's *signature* (argument and return
+types), and that information only exists in a few places, which are very
+unequal:
+
+| Source                              | Names? | Types? | Notes |
+|-------------------------------------|--------|--------|-------|
+| Dynamic symbol table (`.dynsym`)    | yes    | no     | Plain C strips types from the ABI — you get `pow`, not its signature. |
+| DWARF debug info (`-g` builds)      | yes    | yes    | Almost always stripped from distributed `.so`s; unreliable. |
+| The C header                        | yes    | yes    | The real source of signatures — but headers are the hard part (preprocessor, macros, typedefs, nested includes, platform `#ifdef`s). |
+
+So a symbol table alone gives a *name list without types* — not enough to call
+anything. "Generate from a header" therefore means "parse C," which is the
+crux of the tool.
+
+### Dev-time codegen, not a runtime import
+
+The generator is an **offline** command that emits a checked-in `.rn` binding
+file — the same model as Rust's `bindgen`, Python's `ctypesgen`, and Zig's own
+`@cImport`:
+
+```
+runic cbind ./vendor/SDL2/SDL.h --lib libSDL2.so -o sdl2.rn
+```
+
+The result is imported normally (`import "./sdl2.rn"`). Keeping it offline
+matters:
+
+- parsing C needs a C toolchain/parser present, which the *script runtime*
+  should never depend on;
+- the runtime FFI stays simple — it only ever consumes `extern fn`, and the
+  generator is the only thing that touches C;
+- bindings become reviewable, cacheable, and hand-editable (the ambiguous
+  cases below *want* a human override).
+
+### Parsing the header
+
+Two realistic backends:
+
+- **`zig translate-c` (recommended first cut).** Runic is already a Zig
+  project, so `zig` is in the dev environment. `zig translate-c header.h` runs
+  Clang internally and emits *Zig* with every typedef resolved to primitives
+  (`pub extern fn SDL_CreateWindow(title: [*c]const u8, x: c_int, ...) ?*SDL_Window`).
+  Parsing that regular, one-decl-per-line output and mapping `c_int → CInt`,
+  `f64 → CDouble`, `[*c]const u8 → CStr`, `?*T → CPtr`, … is far easier than
+  parsing C, and leans on Clang's correctness without embedding it.
+- **libclang (robust version, later).** Link libclang, walk
+  `CXCursor_FunctionDecl` cursors, read `clang_getResultType` /
+  `clang_getArgType`, map `CXType` kinds to the C-types. This is what `bindgen`
+  does — no fragile parsing of generated Zig, full control, but a real
+  dependency and more code.
+
+Rolling a bespoke C parser is the trap: headers are too gnarly. Don't.
+
+### What the generator cannot fully do
+
+Auto-generation covers most of a library, not all of it, and the tool should
+**report what it skipped** rather than emit something that miscompiles or
+crashes at the call:
+
+- **`char*` ambiguity** — string (`CStr`) or mutable byte buffer (`CPtr`)? The
+  header does not say. Heuristic: `const char* → CStr`, `char* → CPtr`, with a
+  hand override when wrong.
+- **struct-by-value / varargs** — not callable until the libffi phase, so they
+  are skipped with a commented stub and a count (`// skipped 34: struct-by-value / variadic`).
+- **function pointers** (callbacks) — deferred to the callback phase.
+- **`size_t`, `enum`s, unsigned variants** — need the fuller C-type set
+  (`CSizeT`, `CUInt`, …) noted in the open questions.
+
+### Symbol-only fallback
+
+`runic cbind --lib libfoo.so` with *no* header can still read `.dynsym` and
+emit a stub `cimport` block with every symbol name filled in and `// TODO:`
+types. Not callable as-is, but it saves typing the names and shows the surface
+area when no header is available.
+
+## Phased plan
+
+0. **Vendor + link `libffi`** — get `libffi` compiling from vendored source and
+   statically linked into `runic` via `build.zig` for the primary dev target,
+   with a trivial `ffi_call` smoke test. This is the load-bearing prerequisite;
+   the calling mechanism depends on it.
+1. **MVP** — `cimport` + `extern fn`, `std.DynLib` loading, the scalar C-type
+   set, `ffi_cif`/`ffi_call` dispatch, `CStr` in/out and `CPtr` handles. Enough
+   for `libm`, and for a project's own scalar `.so` API.
+2. **Ergonomics** — clean load/symbol errors as catchable Runic errors; a
+   documented ownership contract; a smoke example (`examples/`) calling `libm`;
+   the per-target `libffi` header/asm matrix filled in for the release targets.
+3. **`runic cbind` generator** — a dev-time command that emits a `.rn` binding
+   file from a C header (via `zig translate-c`), plus the `.dynsym`-only
+   fallback. Removes the hand-written `extern fn` tedium for large libraries.
+4. **Structs / varargs** — `libffi` already calls them; this phase is the
+   marshalling side (struct-layout `ffi_type`s, Runic ↔ struct value mapping).
+5. **Later / maybe** — a libclang backend for `cbind`; the pure-Zig trampoline
+   fallback (if the `libffi` build matrix proves a burden); Runic → C callbacks;
+   a `--safe` gate; typed pointer views over `CPtr` memory.
+
+## Open questions / risks
+
+- **Vendoring `libffi` into a Zig build.** `libffi` needs per-target
+  configure-generated headers (`fficonfig.h`, `ffitarget.h`) and per-arch
+  assembly; committing those for each release target is the main build cost and
+  the thing that erodes Zig's otherwise trivial cross-compilation. **First check
+  whether a maintained Zig package/`build.zig` port of `libffi` already exists**
+  (e.g. on the Zig package index) before hand-vendoring — it may remove most of
+  this work.
+- **The pure-Zig trampoline fallback** (see *Calling*) stays a documented
+  escape hatch if the `libffi` build matrix becomes a burden; its own risk is
+  that the GP/SSE class split only holds on SysV AMD64 / AArch64 and would need
+  a per-ABI implementation.
+- **`CInt` vs `CLong` width** and signed/unsigned variants — the table above is
+  a starting point; the full set (`CUInt`, `CShort`, `CSizeT`, …) needs deciding.
+- **Threading/reentrancy** — Runic already runs pipeline stages on threads;
+  calling non-thread-safe C from multiple stages is a caller hazard to document.
+- **Windows** (`.dll`, stdcall vs cdecl) is out of scope for the MVP but the
+  `DynLib` layer already abstracts loading.
+- **Whether `cimport` is the right surface** vs. reusing `import` with a
+  modifier, and whether the extern block should live inline or in a separate
+  binding file (a "Runic header" for a C lib).

--- a/src/frontend/lexer.zig
+++ b/src/frontend/lexer.zig
@@ -432,6 +432,9 @@ pub const Lexer = struct {
                     try self.pushContext(.interp());
                     return self.finish(.startAt(start), .string_text);
                 }
+                // A lone `$` not starting an interpolation is literal string
+                // text; consume it (otherwise the loop re-reads it forever).
+                _ = self.advance();
                 continue;
             }
             if (ch == '\n' or ch == '\r') break;

--- a/src/lsp/server.zig
+++ b/src/lsp/server.zig
@@ -358,9 +358,11 @@ pub const Server = struct {
 
         try self.workspace.resetRoots(roots.items);
         try self.workspace.refresh();
-        if (has_explicit_root) self.workspace.indexWorkspace();
+        // The workspace scan is deferred to the first workspace-wide request
+        // (see Workspace.ensureIndexed); initialize must return promptly and
+        // never block on parsing every file under the root.
+        self.workspace.should_index = has_explicit_root;
         self.initialized = true;
-        try self.log("workspace indexed {d} documents", .{self.documents.map.count()});
         try self.sendInitializeResult(id);
     }
 
@@ -842,6 +844,7 @@ pub const Server = struct {
         id: types.RequestId,
         params: types.DefinitionParams,
     ) !void {
+        self.workspace.ensureIndexed();
         const path = try self.resolveUriPath(params.textDocument.uri);
         defer self.allocator.free(path);
 
@@ -964,6 +967,7 @@ pub const Server = struct {
         id: types.RequestId,
         params: types.ReferenceParams,
     ) !void {
+        self.workspace.ensureIndexed();
         const path = try self.resolveUriPath(params.textDocument.uri);
         defer self.allocator.free(path);
 
@@ -1459,6 +1463,7 @@ pub const Server = struct {
         id: types.RequestId,
         params: types.WorkspaceSymbolParams,
     ) !void {
+        self.workspace.ensureIndexed();
         var arena = std.heap.ArenaAllocator.init(self.allocator);
         defer arena.deinit();
         const arena_allocator = arena.allocator();
@@ -1563,6 +1568,7 @@ pub const Server = struct {
         id: types.RequestId,
         params: types.RenameParams,
     ) !void {
+        self.workspace.ensureIndexed();
         const path = try self.resolveUriPath(params.textDocument.uri);
         defer self.allocator.free(path);
 

--- a/src/lsp/server.zig
+++ b/src/lsp/server.zig
@@ -1925,11 +1925,18 @@ pub const Server = struct {
     }
 
     fn sendJson(self: *Server, json_body: anytype) !void {
-        try self.log("Sent JSON: {f}", .{std.json.fmt(json_body, .{ .emit_null_optional_fields = false })});
+        // The wire and the log MUST use the same options, or the JSON you
+        // inspect while debugging differs from what the client actually
+        // receives. `emit_null_optional_fields = false` also keeps responses on
+        // the JSON-RPC result-XOR-error shape (no stray `"error": null` beside a
+        // result). An explicit null result is passed as `std.json.Value.null`,
+        // whose optional wrapper is non-null, so it still serializes.
+        const options: std.json.Stringify.Options = .{ .emit_null_optional_fields = false };
+        try self.log("Sent JSON: {f}", .{std.json.fmt(json_body, options)});
 
         var buffer: [MAX_OUT_CONTENT]u8 = undefined;
         var writer = std.Io.Writer.fixed(&buffer);
-        try writer.print("{f}", .{std.json.fmt(json_body, .{})});
+        try writer.print("{f}", .{std.json.fmt(json_body, options)});
         const body = writer.buffered();
 
         try self.writer.print("Content-Length: {d}\r\n\r\n", .{body.len});

--- a/src/lsp/server.zig
+++ b/src/lsp/server.zig
@@ -119,7 +119,16 @@ pub const Server = struct {
     }
 
     fn handleEnvelope(self: *Server, envelopePayload: []u8) !bool {
-        const parsed: std.json.Parsed(types.ClientRequest) = try std.json.parseFromSlice(types.ClientRequest, self.allocator, envelopePayload, .{ .ignore_unknown_fields = true });
+        // A malformed body (invalid JSON, or JSON that isn't a well-formed
+        // request) must not end the session: drop it and keep serving. Erroring
+        // here would propagate out of run() and kill the server on a single bad
+        // message. We can't reliably recover an id from an unparseable body, so
+        // there is no response to send — dropping is the correct, resilient
+        // behavior.
+        const parsed: std.json.Parsed(types.ClientRequest) = std.json.parseFromSlice(types.ClientRequest, self.allocator, envelopePayload, .{ .ignore_unknown_fields = true }) catch |err| {
+            try self.log("dropping malformed request: {}", .{err});
+            return true;
+        };
         defer parsed.deinit();
 
         const request = parsed.value;

--- a/src/lsp/types.zig
+++ b/src/lsp/types.zig
@@ -522,6 +522,13 @@ pub const Position = struct {
         var i: u32 = 0;
 
         while (column != self.character or line != self.line) : (i += 1) {
+            // A position past end-of-file (a line beyond the document, or a
+            // character past the end of an existing line) does not resolve to
+            // an index. Without this guard `source[i]` reads out of bounds and
+            // crashes the server, because the early-out below only fires once
+            // BOTH line and column overshoot — which never happens for an
+            // over-long character on a valid line.
+            if (i >= source.len) return null;
             switch (source[i]) {
                 '\\' => {
                     if (i < source.len - 1) {
@@ -2149,4 +2156,16 @@ test "workspace edit documentChanges hold bare TextDocumentEdits" {
     try std.testing.expect(std.mem.indexOf(u8, s, "\"textDocumentEdit\"") == null);
     try std.testing.expect(std.mem.indexOf(u8, s, "\"textDocument\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, s, "\"edits\"") != null);
+}
+
+test "Position.findIndex returns null for out-of-bounds positions" {
+    const source = "const foo = 1\n";
+
+    // A character past the end of an existing line: the old guard never fired
+    // (line never overshoots), so `source[i]` ran off the end and crashed.
+    try std.testing.expectEqual(@as(?u32, null), (Position{ .line = 0, .character = 999 }).findIndex(source));
+    // A line past the end of the document.
+    try std.testing.expectEqual(@as(?u32, null), (Position{ .line = 50, .character = 0 }).findIndex(source));
+    // An in-bounds position still resolves to its byte offset (`foo` at col 6).
+    try std.testing.expectEqual(@as(?u32, 6), (Position{ .line = 0, .character = 6 }).findIndex(source));
 }

--- a/src/lsp/types.zig
+++ b/src/lsp/types.zig
@@ -407,6 +407,18 @@ pub const IntegerOrString = union(enum) {
             else => return error.UnexpectedToken,
         };
     }
+
+    /// Serialize as the bare scalar (`5` or `"tok"`), never the wrapped
+    /// `{"integer": 5}` a default tagged union would emit — an outbound
+    /// `ProgressToken` must be a raw integer or string.
+    pub fn jsonStringify(
+        self: @This(),
+        stringify: *std.json.Stringify,
+    ) std.json.Stringify.Error!void {
+        switch (self) {
+            inline else => |payload| try stringify.write(payload),
+        }
+    }
 };
 
 pub const TextDocumentItem = struct {
@@ -1439,6 +1451,14 @@ pub const InsertTextMode = enum(u32) {
     ///
     /// Consider a line like this: <2tabs><cursor><3tabs>foo. Accepting a multi line completion item is indented using 2 tabs and all following lines inserted will be indented using 2 tabs as well.
     adjustIndentation = 2,
+
+    /// LSP requires the numeric code, not the tag name. See `InsertTextFormat`.
+    pub fn jsonStringify(
+        self: @This(),
+        stringify: *std.json.Stringify,
+    ) std.json.Stringify.Error!void {
+        try stringify.write(@intFromEnum(self));
+    }
 };
 
 pub const CompletionItem = struct {
@@ -1613,6 +1633,14 @@ pub const CompletionItemKind = enum(u32) {
 pub const CompletionItemTag = enum(u32) {
     /// Render a completion as obsolete, usually using a strike-out.
     deprecated = 1,
+
+    /// LSP requires the numeric code, not the tag name. See `DiagnosticTag`.
+    pub fn jsonStringify(
+        self: @This(),
+        stringify: *std.json.Stringify,
+    ) std.json.Stringify.Error!void {
+        try stringify.write(@intFromEnum(self));
+    }
 };
 
 /// A `MarkupContent` literal represents a string value which content is interpreted base on its kind flag. Currently the protocol supports `plaintext` and `markdown` as markup kinds.
@@ -1704,6 +1732,20 @@ pub const TextDocumentEdit = struct {
 
 pub const DocumentChangeOperation = union(enum) {
     textDocumentEdit: TextDocumentEdit,
+
+    /// LSP's `documentChanges` array holds each operation object *directly*
+    /// (a bare `TextDocumentEdit`, etc.). Zig's default tagged-union encoding
+    /// would wrap the payload as `{"textDocumentEdit": {...}}`, which clients
+    /// reject (nvim: "attempt to index local 'text_document' (a nil value)").
+    /// Serialize only the active payload so the object is unwrapped.
+    pub fn jsonStringify(
+        self: @This(),
+        stringify: *std.json.Stringify,
+    ) std.json.Stringify.Error!void {
+        switch (self) {
+            inline else => |payload| try stringify.write(payload),
+        }
+    }
 };
 
 pub const WorkspaceEdit = struct {
@@ -2043,4 +2085,68 @@ test "client request parses textDocument/documentSymbol" {
     try std.testing.expect(parsed.value.payload != null);
     try std.testing.expectEqualStrings("textDocument/documentSymbol", parsed.value.method);
     try std.testing.expect(std.meta.activeTag(parsed.value.payload.?) == .@"textDocument/documentSymbol");
+}
+
+fn stringifyOwned(allocator: Allocator, value: anytype) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{f}", .{std.json.fmt(value, .{ .emit_null_optional_fields = false })});
+}
+
+test "outbound enums serialize as numeric codes, not tag names" {
+    const allocator = std.testing.allocator;
+
+    // Each must emit its integer code. A default enum encoding would emit the
+    // tag name string, which clients reject (they expect the LSP number).
+    const cases = .{
+        .{ InsertTextMode.adjustIndentation, "2" },
+        .{ CompletionItemKind.function, "3" },
+        .{ SymbolKind.method, "6" },
+        .{ DiagnosticSeverity.warning, "2" },
+        .{ InlayHintKind.parameter, "2" },
+    };
+    inline for (cases) |case| {
+        const s = try stringifyOwned(allocator, case[0]);
+        defer allocator.free(s);
+        try std.testing.expectEqualStrings(case[1], s);
+    }
+
+    // CompletionItemTag lives in an array; the whole slice must be numeric.
+    const tags = [_]CompletionItemTag{.deprecated};
+    const tags_json = try stringifyOwned(allocator, @as([]const CompletionItemTag, &tags));
+    defer allocator.free(tags_json);
+    try std.testing.expectEqualStrings("[1]", tags_json);
+}
+
+test "IntegerOrString serializes as a bare scalar, not a wrapped union" {
+    const allocator = std.testing.allocator;
+
+    const as_int = try stringifyOwned(allocator, IntegerOrString{ .integer = 7 });
+    defer allocator.free(as_int);
+    try std.testing.expectEqualStrings("7", as_int);
+
+    const as_str = try stringifyOwned(allocator, IntegerOrString{ .string = "tok" });
+    defer allocator.free(as_str);
+    try std.testing.expectEqualStrings("\"tok\"", as_str);
+}
+
+test "workspace edit documentChanges hold bare TextDocumentEdits" {
+    const allocator = std.testing.allocator;
+
+    const edits = [_]TextEdit{.{
+        .range = .{ .start = .{ .line = 0, .character = 0 }, .end = .{ .line = 0, .character = 3 } },
+        .newText = "bar",
+    }};
+    const ops = [_]DocumentChangeOperation{.{ .textDocumentEdit = .{
+        .textDocument = .{ .uri = "file:///x.rn", .version = null },
+        .edits = &edits,
+    } }};
+    const edit = WorkspaceEdit{ .documentChanges = &ops };
+
+    const s = try stringifyOwned(allocator, edit);
+    defer allocator.free(s);
+
+    // The tag-wrapped shape (`{"textDocumentEdit": ...}`) is what broke nvim's
+    // apply_workspace_edit; each element must be the TextDocumentEdit directly.
+    try std.testing.expect(std.mem.indexOf(u8, s, "\"textDocumentEdit\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, s, "\"textDocument\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, s, "\"edits\"") != null);
 }

--- a/src/lsp/workspace.zig
+++ b/src/lsp/workspace.zig
@@ -59,6 +59,13 @@ pub const Workspace = struct {
     documents: *LspDocumentStore,
     env_map: *std.process.Environ.Map,
     type_checker: runic.semantic.TypeChecker,
+    /// Whether the workspace roots should be scanned into the index. Set only
+    /// for client-provided roots (never the current-directory fallback).
+    should_index: bool = false,
+    /// Whether the one-time workspace scan has run yet. The scan is lazy — it
+    /// happens on the first workspace-wide request, not at initialize — so a
+    /// slow or pathological file can never block startup.
+    indexed: bool = false,
 
     pub fn init(
         io: std.Io,
@@ -166,14 +173,25 @@ pub const Workspace = struct {
         try self.index.append(self.allocator, entry);
     }
 
+    /// Runs the one-time workspace scan if it is enabled and has not run yet.
+    /// Called lazily from workspace-wide requests (symbol search, references,
+    /// rename, cross-file definition) rather than at initialize, so the cost —
+    /// or a pathological file — only ever affects the first such request, never
+    /// startup or the per-file features (hover, completion, diagnostics).
+    pub fn ensureIndexed(self: *Workspace) void {
+        if (self.indexed or !self.should_index) return;
+        self.indexed = true;
+        self.indexWorkspace();
+    }
+
     /// Walks the workspace roots and loads every `.rn` file into the document
     /// store so its symbols are available to workspace search and cross-file
-    /// navigation. Called only for roots the client explicitly provided (never
-    /// the current-directory fallback, which could be an arbitrarily large tree).
-    pub fn indexWorkspace(self: *Workspace) void {
+    /// navigation. Scans only roots the client explicitly provided (never the
+    /// current-directory fallback, which could be an arbitrarily large tree).
+    fn indexWorkspace(self: *Workspace) void {
         for (self.roots.items) |root| {
-            // A scan failure (e.g. an unreadable directory) must not abort
-            // startup — the server still works with whatever was indexed.
+            // A scan failure (e.g. an unreadable directory) must not abort the
+            // request — the server still works with whatever was indexed.
             self.scanRoot(root) catch |err| {
                 std.log.err("workspace scan failed for {s}: {}", .{ root, err });
             };

--- a/tests/features/string_dollar_literal_regression.rn
+++ b/tests/features/string_dollar_literal_regression.rn
@@ -1,0 +1,4 @@
+// A lone `$` in a string (not starting a `${...}` interpolation) is literal
+// text. This used to hang the lexer in an infinite loop.
+const label = "cost is $5, $r and a bare $ stay literal"
+echo "${label}"

--- a/tests/features/string_dollar_literal_regression.stdout
+++ b/tests/features/string_dollar_literal_regression.stdout
@@ -1,0 +1,1 @@
+cost is $5, $r and a bare $ stay literal

--- a/tests/lsp_protocol.zig
+++ b/tests/lsp_protocol.zig
@@ -2356,6 +2356,112 @@ test "lsp references report exact identifier ranges" {
     try std.testing.expect(saw_use);
 }
 
+test "lsp survives out-of-bounds position requests" {
+    const allocator = std.testing.allocator;
+    var fixture = try TestFixture.init(allocator);
+    defer fixture.deinit();
+
+    const uri = try fixture.writeDocument("main.rn",
+        \\const foo = 1
+        \\
+    );
+    defer allocator.free(uri);
+
+    const messages = [_][]const u8{
+        try makeDidOpen(allocator, uri,
+            \\const foo = 1
+            \\
+        ),
+        // A line far past EOF and an over-long character — both used to run the
+        // position scan off the end of the buffer and crash the server.
+        try makeHoverRequest(allocator, 2, uri, 999, 999),
+        try makeDefinitionRequest(allocator, 3, uri, 0, 999),
+        // A valid request afterwards must still be answered — proof the server
+        // stayed alive through the out-of-bounds ones.
+        try makeDocumentSymbolRequest(allocator, 4, uri),
+    };
+    defer for (messages) |message| allocator.free(message);
+
+    const output = try runServerWithMessages(allocator, &messages);
+    defer allocator.free(output);
+
+    // Each out-of-bounds request gets a well-formed response instead of taking
+    // the server down.
+    for ([_]i64{ 2, 3 }) |id| {
+        const response = try findResponseById(allocator, output, id);
+        defer allocator.free(response.body);
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, response.body, .{});
+        defer parsed.deinit();
+        try std.testing.expect(parsed.value.object.get("result") != null);
+    }
+
+    // The later valid request was still served.
+    const final = try findResponseById(allocator, output, 4);
+    defer allocator.free(final.body);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, final.body, .{});
+    defer parsed.deinit();
+    try std.testing.expect(parsed.value.object.get("result").?.array.items.len >= 1);
+}
+
+test "lsp returns method-not-found for an unknown request method" {
+    const allocator = std.testing.allocator;
+    const request = try toJsonAlloc(allocator, .{
+        .jsonrpc = "2.0",
+        .id = 7,
+        .method = "textDocument/thisMethodDoesNotExist",
+        .params = .{},
+    });
+    const messages = [_][]const u8{request};
+    defer for (messages) |message| allocator.free(message);
+
+    const output = try runServerWithMessages(allocator, &messages);
+    defer allocator.free(output);
+
+    const response = try findResponseById(allocator, output, 7);
+    defer allocator.free(response.body);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, response.body, .{});
+    defer parsed.deinit();
+
+    // Error response: `error` present with the JSON-RPC method-not-found code,
+    // and no `result` field (result-XOR-error).
+    const root = parsed.value.object;
+    try std.testing.expect(root.get("result") == null);
+    const err = root.get("error").?.object;
+    try std.testing.expectEqual(@as(i64, -32601), err.get("code").?.integer);
+}
+
+test "lsp rejects a second initialize with an already-initialized error" {
+    const allocator = std.testing.allocator;
+    const messages = [_][]const u8{
+        try makeInitialize(allocator, 1, true),
+        try makeInitialize(allocator, 2, true),
+    };
+    defer for (messages) |message| allocator.free(message);
+
+    const output = try runServerWithMessages(allocator, &messages);
+    defer allocator.free(output);
+
+    // First initialize succeeds.
+    {
+        const response = try findResponseById(allocator, output, 1);
+        defer allocator.free(response.body);
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, response.body, .{});
+        defer parsed.deinit();
+        try std.testing.expect(parsed.value.object.get("result") != null);
+        try std.testing.expect(parsed.value.object.get("error") == null);
+    }
+    // The second is rejected as invalid (-32600), not silently re-run.
+    {
+        const response = try findResponseById(allocator, output, 2);
+        defer allocator.free(response.body);
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, response.body, .{});
+        defer parsed.deinit();
+        try std.testing.expect(parsed.value.object.get("result") == null);
+        const err = parsed.value.object.get("error").?.object;
+        try std.testing.expectEqual(@as(i64, -32600), err.get("code").?.integer);
+    }
+}
+
 const TestFixture = struct {
     allocator: Allocator,
     tmp_dir: std.testing.TmpDir,

--- a/tests/lsp_protocol.zig
+++ b/tests/lsp_protocol.zig
@@ -243,7 +243,7 @@ test "lsp rename returns concrete same-file edits" {
 
     const changes = parsed.value.object.get("result").?.object.get("documentChanges").?.array.items;
     try std.testing.expectEqual(@as(usize, 1), changes.len);
-    const edits = changes[0].object.get("textDocumentEdit").?.object.get("edits").?.array.items;
+    const edits = changes[0].object.get("edits").?.array.items;
     try std.testing.expectEqual(@as(usize, 2), edits.len);
 
     for (edits) |edit| {
@@ -299,7 +299,7 @@ test "lsp rename edits every indexed file that references the symbol" {
     var saw_helper = false;
     var saw_main = false;
     for (changes) |change| {
-        const tde = change.object.get("textDocumentEdit").?.object;
+        const tde = change.object;
         const uri = tde.get("textDocument").?.object.get("uri").?.string;
         const edits = tde.get("edits").?.array.items;
         try std.testing.expect(edits.len >= 1);
@@ -419,7 +419,7 @@ test "lsp rename of a module member edits the module declaration and the access"
     var saw_other = false;
     var saw_importer2 = false;
     for (changes) |change| {
-        const tde = change.object.get("textDocumentEdit").?.object;
+        const tde = change.object;
         const uri = tde.get("textDocument").?.object.get("uri").?.string;
         const edits = tde.get("edits").?.array.items;
         try std.testing.expect(edits.len >= 1);
@@ -475,7 +475,7 @@ test "lsp rename is scoped to the binding, not every same-named identifier" {
 
     const changes = parsed.value.object.get("result").?.object.get("documentChanges").?.array.items;
     try std.testing.expectEqual(@as(usize, 1), changes.len);
-    const edits = changes[0].object.get("textDocumentEdit").?.object.get("edits").?.array.items;
+    const edits = changes[0].object.get("edits").?.array.items;
 
     // Only the two occurrences inside function a (lines 1 and 2) are renamed;
     // function b's `x` on lines 5 and 6 is a different binding and left alone.
@@ -522,7 +522,7 @@ test "lsp rename ignores strings and comments" {
     defer parsed.deinit();
 
     const changes = parsed.value.object.get("result").?.object.get("documentChanges").?.array.items;
-    const edits = changes[0].object.get("textDocumentEdit").?.object.get("edits").?.array.items;
+    const edits = changes[0].object.get("edits").?.array.items;
     try std.testing.expectEqual(@as(usize, 2), edits.len);
     for (edits) |edit| {
         try std.testing.expectEqualStrings("bar", edit.object.get("newText").?.string);
@@ -1298,7 +1298,7 @@ test "lsp code action adds an inferred type annotation" {
     try std.testing.expectEqualStrings("Add type annotation: Int", action.get("title").?.string);
 
     const edits = action.get("edit").?.object.get("documentChanges").?.array
-        .items[0].object.get("textDocumentEdit").?.object.get("edits").?.array.items;
+        .items[0].object.get("edits").?.array.items;
     try std.testing.expectEqual(@as(usize, 1), edits.len);
     try std.testing.expectEqualStrings(": Int", edits[0].object.get("newText").?.string);
     // Inserted right after the identifier `x` (column 7 on line 0).

--- a/tests/lsp_protocol.zig
+++ b/tests/lsp_protocol.zig
@@ -342,9 +342,16 @@ test "lsp prepare rename returns the identifier range, or null off an identifier
         defer parsed.deinit();
         const result = parsed.value.object.get("result").?.object;
         try std.testing.expectEqualStrings("foo", result.get("placeholder").?.string);
-        const start = result.get("range").?.object.get("start").?.object;
+        const range = result.get("range").?.object;
+        const start = range.get("start").?.object;
         try std.testing.expectEqual(@as(i64, 0), start.get("line").?.integer);
         try std.testing.expectEqual(@as(i64, 6), start.get("character").?.integer);
+        // The range must END where `foo` ends (col 9), not one short or one
+        // long — a span-width off-by-one in the 1↔0-indexed conversion would
+        // rename only `fo`/`foo `.
+        const end = range.get("end").?.object;
+        try std.testing.expectEqual(@as(i64, 0), end.get("line").?.integer);
+        try std.testing.expectEqual(@as(i64, 9), end.get("character").?.integer);
     }
 
     // Off any identifier (on `=`): null, so the client blocks the rename.
@@ -2228,6 +2235,125 @@ test "lsp success responses carry a result and omit the error field" {
     try std.testing.expectEqualStrings("2.0", root.get("jsonrpc").?.string);
     try std.testing.expect(root.get("result") != null);
     try std.testing.expect(root.get("error") == null);
+}
+
+// A single edit/location range, flattened for exact-coordinate assertions.
+const RangeSpan = struct {
+    line: i64,
+    start_char: i64,
+    end_line: i64,
+    end_char: i64,
+    new_text: []const u8,
+};
+
+fn spanOf(obj: std.json.ObjectMap, new_text_key: ?[]const u8) RangeSpan {
+    const range = obj.get("range").?.object;
+    const start = range.get("start").?.object;
+    const end = range.get("end").?.object;
+    return .{
+        .line = start.get("line").?.integer,
+        .start_char = start.get("character").?.integer,
+        .end_line = end.get("line").?.integer,
+        .end_char = end.get("character").?.integer,
+        .new_text = if (new_text_key) |k| obj.get(k).?.string else "",
+    };
+}
+
+test "lsp rename edits span exactly the identifier at precise coordinates" {
+    const allocator = std.testing.allocator;
+    var fixture = try TestFixture.init(allocator);
+    defer fixture.deinit();
+
+    // `alpha` appears at (0,6)-(0,11) and (1,13)-(1,18): non-zero line and a
+    // non-zero column, so both the line and character conversions are exercised,
+    // and the 5-char span guards the range width.
+    const source =
+        \\const alpha = 1
+        \\const beta = alpha
+        \\
+    ;
+    const uri = try fixture.writeDocument("main.rn", source);
+    defer allocator.free(uri);
+
+    const messages = [_][]const u8{
+        try makeDidOpen(allocator, uri, source),
+        try makeRenameRequest(allocator, 2, uri, 0, 6, "renamed"),
+    };
+    defer for (messages) |message| allocator.free(message);
+
+    const output = try runServerWithMessages(allocator, &messages);
+    defer allocator.free(output);
+
+    const response = try findResponseById(allocator, output, 2);
+    defer allocator.free(response.body);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, response.body, .{});
+    defer parsed.deinit();
+
+    const changes = parsed.value.object.get("result").?.object.get("documentChanges").?.array.items;
+    try std.testing.expectEqual(@as(usize, 1), changes.len);
+    const edits = changes[0].object.get("edits").?.array.items;
+    try std.testing.expectEqual(@as(usize, 2), edits.len);
+
+    var saw_decl = false;
+    var saw_use = false;
+    for (edits) |edit| {
+        const span = spanOf(edit.object, "newText");
+        try std.testing.expectEqualStrings("renamed", span.new_text);
+        // Every edit is single-line and spans exactly the 5 chars of `alpha`.
+        try std.testing.expectEqual(span.line, span.end_line);
+        try std.testing.expectEqual(span.start_char + 5, span.end_char);
+        if (span.line == 0 and span.start_char == 6) saw_decl = true;
+        if (span.line == 1 and span.start_char == 13) saw_use = true;
+    }
+    try std.testing.expect(saw_decl);
+    try std.testing.expect(saw_use);
+}
+
+test "lsp references report exact identifier ranges" {
+    const allocator = std.testing.allocator;
+    var fixture = try TestFixture.init(allocator);
+    defer fixture.deinit();
+
+    // `count` at declaration (0,6)-(0,11) and use (1,8)-(1,13) — inside the
+    // interpolation `echo "${count}"`, where `${` occupies cols 6-7.
+    const source =
+        \\const count = 3
+        \\echo "${count}"
+        \\
+    ;
+    const uri = try fixture.writeDocument("main.rn", source);
+    defer allocator.free(uri);
+
+    const messages = [_][]const u8{
+        try makeDidOpen(allocator, uri, source),
+        try makeReferencesRequest(allocator, 2, uri, 0, 6, true),
+    };
+    defer for (messages) |message| allocator.free(message);
+
+    const output = try runServerWithMessages(allocator, &messages);
+    defer allocator.free(output);
+
+    const response = try findResponseById(allocator, output, 2);
+    defer allocator.free(response.body);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, response.body, .{});
+    defer parsed.deinit();
+
+    const results = parsed.value.object.get("result").?.array.items;
+    try std.testing.expectEqual(@as(usize, 2), results.len);
+
+    var saw_decl = false;
+    var saw_use = false;
+    for (results) |item| {
+        try std.testing.expectEqualStrings(uri, item.object.get("uri").?.string);
+        const span = spanOf(item.object, null);
+        // Every occurrence is single-line and spans exactly `count` (5 chars).
+        try std.testing.expectEqual(span.line, span.end_line);
+        try std.testing.expectEqual(span.start_char + 5, span.end_char);
+        if (span.line == 0 and span.start_char == 6) saw_decl = true;
+        if (span.line == 1 and span.start_char == 8) saw_use = true;
+    }
+    try std.testing.expect(saw_decl);
+    try std.testing.expect(saw_use);
 }
 
 const TestFixture = struct {

--- a/tests/lsp_protocol.zig
+++ b/tests/lsp_protocol.zig
@@ -1296,6 +1296,11 @@ test "lsp code action adds an inferred type annotation" {
     try std.testing.expectEqual(@as(usize, 1), actions.len);
     const action = actions[0].object;
     try std.testing.expectEqualStrings("Add type annotation: Int", action.get("title").?.string);
+    // CodeActionKind is a protocol string ("refactor.rewrite"), not a numeric
+    // enum code — assert it stays a string so the classification reaches clients.
+    if (action.get("kind")) |kind| {
+        try std.testing.expect(kind == .string);
+    }
 
     const edits = action.get("edit").?.object.get("documentChanges").?.array
         .items[0].object.get("edits").?.array.items;
@@ -1767,7 +1772,12 @@ test "lsp hover shows execution result type for bound command" {
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, response.body, .{});
     defer parsed.deinit();
 
-    const value = parsed.value.object.get("result").?.object.get("contents").?.object.get("value").?.string;
+    const contents = parsed.value.object.get("result").?.object.get("contents").?.object;
+    // MarkupContent.kind is a MarkupKind, which the protocol encodes as a STRING
+    // ("markdown"/"plaintext") — not a numeric code like the other kind enums.
+    const kind = contents.get("kind").?.string;
+    try std.testing.expect(std.mem.eql(u8, kind, "markdown") or std.mem.eql(u8, kind, "plaintext"));
+    const value = contents.get("value").?.string;
     try std.testing.expect(std.mem.indexOf(u8, value, "ExecutionResult") != null);
 }
 
@@ -2125,6 +2135,99 @@ test "lsp single-level member completion recovers scope after a trailing dot" {
     // The scratch recovery document was closed again, leaving only the real one.
     try std.testing.expectEqual(@as(usize, 1), result.doc_count);
     try std.testing.expectEqualStrings("", result.stderr);
+}
+
+test "lsp initialize advertises capabilities with the correct wire shape" {
+    const allocator = std.testing.allocator;
+    const messages = [_][]const u8{
+        try makeInitialize(allocator, 1, true),
+    };
+    defer for (messages) |message| allocator.free(message);
+
+    const output = try runServerWithMessages(allocator, &messages);
+    defer allocator.free(output);
+
+    const response = try findResponseById(allocator, output, 1);
+    defer allocator.free(response.body);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, response.body, .{});
+    defer parsed.deinit();
+
+    const root = parsed.value.object;
+    // Envelope: a success response carries jsonrpc "2.0" + result and MUST NOT
+    // carry a stray `error` field. sendJson serializes with
+    // emit_null_optional_fields = false so the JSON-RPC result-XOR-error shape
+    // holds; a regression to emit-nulls would put `"error": null` here.
+    try std.testing.expectEqualStrings("2.0", root.get("jsonrpc").?.string);
+    try std.testing.expect(root.get("result") != null);
+    try std.testing.expect(root.get("error") == null);
+
+    const caps = root.get("result").?.object.get("capabilities").?.object;
+
+    // textDocumentSync is an Either(options, kind): it must unwrap to the bare
+    // options object (never a `{"textDocumentSyncOptions": ...}` tag envelope),
+    // and its `change` must be the numeric TextDocumentSyncKind, not a tag name.
+    const sync = caps.get("textDocumentSync").?.object;
+    try std.testing.expect(sync.get("textDocumentSyncOptions") == null);
+    try std.testing.expectEqual(true, sync.get("openClose").?.bool);
+    try std.testing.expectEqual(@as(i64, 2), sync.get("change").?.integer); // incremental
+
+    // A bool-or-options Either capability likewise unwraps to its options object.
+    const rename = caps.get("renameProvider").?.object;
+    try std.testing.expect(rename.get("renameOptions") == null);
+    try std.testing.expectEqual(true, rename.get("prepareProvider").?.bool);
+
+    // completionProvider carries resolveProvider + trigger characters.
+    const completion_provider = caps.get("completionProvider").?.object;
+    try std.testing.expectEqual(true, completion_provider.get("resolveProvider").?.bool);
+    try std.testing.expect(completion_provider.get("triggerCharacters").?.array.items.len > 0);
+
+    // The rest of the advertised providers must be present.
+    const providers = [_][]const u8{
+        "definitionProvider",        "referencesProvider",
+        "hoverProvider",             "documentSymbolProvider",
+        "documentHighlightProvider", "documentLinkProvider",
+        "inlayHintProvider",         "foldingRangeProvider",
+        "codeActionProvider",        "workspaceSymbolProvider",
+    };
+    for (providers) |name| {
+        try std.testing.expect(caps.get(name) != null);
+    }
+}
+
+test "lsp success responses carry a result and omit the error field" {
+    const allocator = std.testing.allocator;
+    var fixture = try TestFixture.init(allocator);
+    defer fixture.deinit();
+
+    const uri = try fixture.writeDocument("main.rn",
+        \\const foo = 1
+        \\
+    );
+    defer allocator.free(uri);
+
+    const messages = [_][]const u8{
+        try makeDidOpen(allocator, uri,
+            \\const foo = 1
+            \\
+        ),
+        try makeDocumentSymbolRequest(allocator, 2, uri),
+    };
+    defer for (messages) |message| allocator.free(message);
+
+    const output = try runServerWithMessages(allocator, &messages);
+    defer allocator.free(output);
+
+    const response = try findResponseById(allocator, output, 2);
+    defer allocator.free(response.body);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, response.body, .{});
+    defer parsed.deinit();
+
+    // A normal (non-initialize) success response must also be result-XOR-error:
+    // the `result` is present and the `error` field is absent, not `null`.
+    const root = parsed.value.object;
+    try std.testing.expectEqualStrings("2.0", root.get("jsonrpc").?.string);
+    try std.testing.expect(root.get("result") != null);
+    try std.testing.expect(root.get("error") == null);
 }
 
 const TestFixture = struct {

--- a/tests/lsp_protocol.zig
+++ b/tests/lsp_protocol.zig
@@ -2513,6 +2513,79 @@ test "lsp clears diagnostics once an invalid document is fixed" {
     }
 }
 
+test "lsp survives a malformed request body" {
+    const allocator = std.testing.allocator;
+    var fixture = try TestFixture.init(allocator);
+    defer fixture.deinit();
+
+    const uri = try fixture.writeDocument("main.rn",
+        \\const foo = 1
+        \\
+    );
+    defer allocator.free(uri);
+
+    const messages = [_][]const u8{
+        // A body that is framed correctly but is not valid JSON — it must be
+        // dropped, not end the session.
+        try allocator.dupe(u8, "{ this is : not valid json ]"),
+        // A valid session afterwards must still be served.
+        try makeDidOpen(allocator, uri,
+            \\const foo = 1
+            \\
+        ),
+        try makeDocumentSymbolRequest(allocator, 2, uri),
+    };
+    defer for (messages) |message| allocator.free(message);
+
+    const output = try runServerWithMessages(allocator, &messages);
+    defer allocator.free(output);
+
+    // The request after the malformed one was answered → the server stayed up.
+    const response = try findResponseById(allocator, output, 2);
+    defer allocator.free(response.body);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, response.body, .{});
+    defer parsed.deinit();
+    try std.testing.expect(parsed.value.object.get("result") != null);
+}
+
+test "lsp handles navigation requests for a never-opened document" {
+    const allocator = std.testing.allocator;
+    var fixture = try TestFixture.init(allocator);
+    defer fixture.deinit();
+
+    // The file exists on disk but is never sent via didOpen, so the server has
+    // no in-memory copy. Every position handler must degrade to a null/empty
+    // result rather than dereferencing the missing document.
+    const uri = try fixture.writeDocument("ghost.rn",
+        \\const foo = 1
+        \\echo foo
+        \\
+    );
+    defer allocator.free(uri);
+
+    const messages = [_][]const u8{
+        try makeHoverRequest(allocator, 1, uri, 1, 5),
+        try makeDefinitionRequest(allocator, 2, uri, 1, 5),
+        try makeReferencesRequest(allocator, 3, uri, 0, 6, true),
+        try makeRenameRequest(allocator, 4, uri, 0, 6, "bar"),
+        try makeDocumentSymbolRequest(allocator, 5, uri),
+    };
+    defer for (messages) |message| allocator.free(message);
+
+    const output = try runServerWithMessages(allocator, &messages);
+    defer allocator.free(output);
+
+    // Every request gets a well-formed response (the `result` key is present),
+    // proving none of the handlers crashed on the missing document.
+    for ([_]i64{ 1, 2, 3, 4, 5 }) |id| {
+        const response = try findResponseById(allocator, output, id);
+        defer allocator.free(response.body);
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, response.body, .{});
+        defer parsed.deinit();
+        try std.testing.expect(parsed.value.object.get("result") != null);
+    }
+}
+
 const TestFixture = struct {
     allocator: Allocator,
     tmp_dir: std.testing.TmpDir,

--- a/tests/lsp_protocol.zig
+++ b/tests/lsp_protocol.zig
@@ -2462,6 +2462,57 @@ test "lsp rejects a second initialize with an already-initialized error" {
     }
 }
 
+test "lsp clears diagnostics once an invalid document is fixed" {
+    const allocator = std.testing.allocator;
+    var fixture = try TestFixture.init(allocator);
+    defer fixture.deinit();
+
+    const uri = try fixture.writeDocument("main.rn",
+        \\const foo =
+        \\
+    );
+    defer allocator.free(uri);
+
+    const messages = [_][]const u8{
+        // Open with an incomplete binding (a parse error), then fix it.
+        try makeDidOpen(allocator, uri,
+            \\const foo =
+            \\
+        ),
+        try makeDidChangeWholeDocument(allocator, uri, 2,
+            \\const foo = 1
+            \\
+        ),
+    };
+    defer for (messages) |message| allocator.free(message);
+
+    const output = try runServerWithMessages(allocator, &messages);
+    defer allocator.free(output);
+
+    // The first publish (on open) reports the error.
+    {
+        const first = try findMethodNotification(allocator, output, "textDocument/publishDiagnostics");
+        defer allocator.free(first);
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, first, .{});
+        defer parsed.deinit();
+        const diagnostics = parsed.value.object.get("params").?.object.get("diagnostics").?.array.items;
+        try std.testing.expect(diagnostics.len > 0);
+    }
+
+    // After the fix, the server MUST republish an empty diagnostics array to
+    // clear the editor — not simply stop publishing, which would leave the stale
+    // error on screen.
+    {
+        const last = try findLastMethodNotification(allocator, output, "textDocument/publishDiagnostics");
+        defer allocator.free(last);
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, last, .{});
+        defer parsed.deinit();
+        const params = parsed.value.object.get("params").?.object;
+        try std.testing.expectEqualStrings(uri, params.get("uri").?.string);
+        try std.testing.expectEqual(@as(usize, 0), params.get("diagnostics").?.array.items.len);
+    }
+}
+
 const TestFixture = struct {
     allocator: Allocator,
     tmp_dir: std.testing.TmpDir,
@@ -2609,6 +2660,37 @@ fn findMethodNotification(allocator: Allocator, output: []const u8, wanted_metho
     }
 
     return error.ResponseNotFound;
+}
+
+/// Like findMethodNotification, but returns the LAST matching notification —
+/// used when a method is published more than once (e.g. diagnostics republished
+/// after an edit) and the test cares about the final state.
+fn findLastMethodNotification(allocator: Allocator, output: []const u8, wanted_method: []const u8) ![]u8 {
+    var offset: usize = 0;
+    var last: ?[]u8 = null;
+    errdefer if (last) |l| allocator.free(l);
+    while (offset < output.len) {
+        const header_end_rel = std.mem.indexOfPos(u8, output, offset, "\r\n\r\n") orelse break;
+        const header_block = output[offset..header_end_rel];
+        const content_length = parseContentLength(header_block) orelse break;
+        const body_start = header_end_rel + 4;
+        const body_end = body_start + content_length;
+        if (body_end > output.len) break;
+
+        const body = output[body_start..body_end];
+        const parsed = try std.json.parseFromSlice(std.json.Value, allocator, body, .{});
+        defer parsed.deinit();
+
+        const method = parsed.value.object.get("method");
+        if (method != null and method.? == .string and std.mem.eql(u8, method.?.string, wanted_method)) {
+            if (last) |l| allocator.free(l);
+            last = try allocator.dupe(u8, body);
+        }
+
+        offset = body_end;
+    }
+
+    return last orelse error.ResponseNotFound;
 }
 
 fn parseContentLength(headers: []const u8) ?usize {


### PR DESCRIPTION
Bug-fix and stabilization release following the 0.8.0 language-server build-out.
  The theme is LSP protocol correctness and resilience — three real crashes/hangs
  fixed, the serialization layer audited end-to-end, and the protocol test suite
  roughly doubled.

  ## Fixes

  - **Rename / code-action edits crashed clients.** A `WorkspaceEdit`'s
    `documentChanges` entries serialized as `{"textDocumentEdit": {…}}` instead of
    the bare `TextDocumentEdit` the protocol requires, so applying a rename or the
    "add type annotation" quick fix failed in editors — Neovim reported
    `attempt to index local 'text_document' (a nil value)`.
  - **Crash on an out-of-bounds position.** A hover/definition/rename at a line
    past EOF, or a character past a line's end, ran the position→offset scan off
    the buffer and hard-crashed the in-process server. Such positions now resolve
    to nothing.
  - **A malformed request killed the session.** An unparseable request body
    propagated an error out of the main loop and terminated the server, dropping
    every request after it. Bad messages are now logged and dropped; the session
    continues.
  - **Remaining protocol encodings.** `InsertTextMode`, `CompletionItemTag`
    (numeric codes) and `ProgressToken` (bare scalar) are guarded, completing the
    numeric-code pass from 0.8.0. Responses are now JSON-RPC result-XOR-error (no
    stray `"error": null`), and the debug log matches the exact bytes on the wire.

  ## Changes

  - **Lazy workspace indexing.** The full `.rn` scan runs on the first
    workspace-wide request (client-provided root only), never at `initialize`, so
    a slow or malformed file can't block startup or the per-file features.
  - **Tree-sitter grammar refreshed** for current syntax (`comptime`, `yield`,
    `is`, hex/octal/binary literals, `||=`/`&&=`); parser generated at ABI 14 for
    editor compatibility (Neovim 0.10).

  ## Tests


  - **Lazy workspace indexing.** The full `.rn` scan runs on the first
    workspace-wide request (client-provided root only), never at `initialize`, so
    a slow or malformed file can't block startup or the per-file features.
  - **Tree-sitter grammar refreshed** for current syntax (`comptime`, `yield`,
    `is`, hex/octal/binary literals, `||=`/`&&=`); parser generated at ABI 14 for
    editor compatibility (Neovim 0.10).

    workspace-wide request (client-provided root only), never at `initialize`, so
    a slow or malformed file can't block startup or the per-file features.
  - **Tree-sitter grammar refreshed** for current syntax (`comptime`, `yield`,
    `is`, hex/octal/binary literals, `||=`/`&&=`); parser generated at ABI 14 for
    editor compatibility (Neovim 0.10).

  ## Tests

  The LSP protocol suite was expanded substantially — response wire shapes
  (numeric enums, unwrapped `documentChanges`, result-XOR-error envelopes), exact


  - **Lazy workspace indexing.** The full `.rn` scan runs on the first
    workspace-wide request (client-provided root only), never at `initialize`, so
    a slow or malformed file can't block startup or the per-file features.
  - **Tree-sitter grammar refreshed** for current syntax (`comptime`, `yield`,
    `is`, hex/octal/binary literals, `||=`/`&&=`); parser generated at ABI 14 for
    editor compatibility (Neovim 0.10).

  ## Tests

  The LSP protocol suite was expanded substantially — response wire shapes
  (numeric enums, unwrapped `documentChanges`, result-XOR-error envelopes), exact
  0↔1-indexed coordinate encoding, robustness (out-of-bounds positions, unknown
  methods `-32601`, duplicate `initialize` `-32600`, malformed bodies, never-opened
  documents), and the diagnostics-clear-on-fix lifecycle. `zig build test` is now
  **126 tests** (was 112).

  ## Verification

  - `zig fmt --check src cmd tests` — clean
  - `zig build run -- scripts/run_ci.rn` — 12/12 build steps, 126/126 unit tests,
    163 CLI smoke scripts, strict-mode all pass
  - `runic --version` → `0.8.1`